### PR TITLE
Update JobType.php: Policy field required

### DIFF
--- a/src/Binovo/ElkarBackupBundle/Form/Type/JobType.php
+++ b/src/Binovo/ElkarBackupBundle/Form/Type/JobType.php
@@ -22,7 +22,7 @@ class JobType extends AbstractType
                                                                 'attr'  => array('class'    => 'span12')))
                 ->add('policy'              , 'entity'  , array('label' => $t->trans('Policy', array(), 'BinovoElkarBackup'),
                                                                 'attr'     => array('class'    => 'span12'),
-                                                                'required' => false,
+                                                                'required' => true,
                                                                 'class'    => 'BinovoElkarBackupBundle:Policy',
                                                                 'property' => 'name'))
                 ->add('useLocalPermissions' , 'checkbox', array('label'    => $t->trans('Use local permissions', array(), 'BinovoElkarBackup'),


### PR DESCRIPTION
Make Policy field required:

Currently, when you create a new Job, you can leave Policy empty and save the job... but it will fail running the job.

I think is better to make it mandatory. With this change, when we create new Job, we'll have selected by default the first policy.
