### PR TITLE
Fix for issue #114

### DIFF
--- a/src/Binovo/ElkarBackupBundle/Controller/DefaultController.php
+++ b/src/Binovo/ElkarBackupBundle/Controller/DefaultController.php
@@ -1107,7 +1107,7 @@ EOF;
             $ok = true;
             $result = $this->redirect($this->generateUrl('manageBackupsLocation'));
             if ($this->container->getParameter('backup_dir') != $backupDir) {
-                if ($this->setParameter('backup_dir', $backupDir)) {
+                if ($this->setParameter('backup_dir', $backupDir, 'manageBackupsLocation')) {
                     $this->get('session')->getFlashBag()->add('manageParameters',
                                                               $t->trans('Parameters updated',
                                                                         array(),
@@ -1189,18 +1189,18 @@ EOF;
                 $ok = true;
                 if ('password' == $params[$paramName]['type']) {
                     if (!empty($paramValue)) {
-                        $ok = $this->setParameter($paramName, $paramValue);
+                        $ok = $this->setParameter($paramName, $paramValue, 'manageParameters');
                     }
                 } elseif ('checkbox' == $params[$paramName]['type']) {
                     // Workaround to store value in boolean format
                     if (!empty($paramValue)) {
-                        $ok = $this->setParameter($paramName, 'true');
+                        $ok = $this->setParameter($paramName, 'true', 'manageParameters');
                     } else {
-                        $ok = $this->setParameter($paramName, 'false');
+                        $ok = $this->setParameter($paramName, 'false', 'manageParameters');
                     }
                 } else {
                     if ($paramValue != $this->container->getParameter($paramName)) {
-                        $ok = $this->setParameter($paramName, $paramValue);
+                        $ok = $this->setParameter($paramName, $paramValue, 'manageParameters');
                     }
                 }
                 if (!$ok) {
@@ -1232,7 +1232,7 @@ EOF;
     /**
      * Sets the value of a filed in the parameters.yml file to the given value
      */
-    public function setParameter($name, $value)
+    public function setParameter($name, $value, $from)
     {
         $paramsFilename = dirname(__FILE__) . '/../../../../app/config/parameters.yml';
         $paramsFile = file_get_contents($paramsFilename);
@@ -1244,11 +1244,11 @@ EOF;
         if ($ok) {
             $this->info('Set Parameter %paramname%',
                         array('%paramname%' => $name),
-                        array('link' => $this->generateUrl('showPolicies')));
+                        array('link' => $this->generateUrl($from)));
         } else {
-            $this->info('Set Parameter %paramname%',
+            $this->info('Warning: Parameter %paramname% not set',
                         array('%paramname%' => $name),
-                        array('link' => $this->generateUrl('showPolicies')));
+                        array('link' => $this->generateUrl($from)));
         }
 
         return $ok;


### PR DESCRIPTION
Fixing issue #114 

		· Modification: setParameter($name, $value, $from) takes a new argument $from
			- this allows to properly set the message for the logger

			- modified every call with the new argument
				@DefaultController::manageParametersAction
				@DefaultController::manageBackupsLocationAction

		· Bugfix: modified the message when the parameter is not set