### PR TITLE
HTTPS virtual host enabled

### DIFF
--- a/debian/DEBIAN/conffiles
+++ b/debian/DEBIAN/conffiles
@@ -1,5 +1,6 @@
 /etc/apache2/conf-available/elkarbackup.conf
 /etc/apache2/sites-available/elkarbackup.conf
+/etc/apache2/sites-available/elkarbackup-ssl.conf
 /etc/auto.nfs4
 /etc/cron.d/elkarbackup
 /etc/sudoers.d/elkarbackup

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -1,11 +1,10 @@
 Package: elkarbackup
-Version: 1.2.0-Pre-Alpha2
+Version: 1.2.0-Pre-Alpha3
 Section: admin
 Priority: optional
 Architecture: all
 Depends: acl, debconf, php5, php5-cli, rsnapshot, mysql-client, php5-mysql, sudo, apache2
 Suggests: autofs5, bzip2, zip, mysql-server, tahoe-lafs
-Replaces: tknikabackups
 Maintainer: Xabi Ezpeleta <xezpeleta@gmail.com>
-Description: Web configurator for Rsnapshot
- Simple Web configurator for rsnapshot
+Description: backup solution with an easy-to-use web interface based on Rsync / RSnapshot
+ ElkarBackup is a free open-source backup solution based on RSync/RSnapshot. It helps to manage centralized backups using a web interface.

--- a/debian/DEBIAN/postinst
+++ b/debian/DEBIAN/postinst
@@ -96,6 +96,9 @@ then
     echo                    >> /etc/elkarbackup/parameters.yml
     echo "    home: /var/lib/elkarbackup" >> /etc/elkarbackup/parameters.yml
 fi
+
+echo Delete cache content
+rm -fR /var/cache/elkarbackup/*
 echo Update DB
 php /usr/share/elkarbackup/app/console doctrine:migrations:migrate --no-interaction >/dev/null || true
 echo Create root user
@@ -146,14 +149,17 @@ service elkarbackup-tahoe-lafs start
 
 if [ "$1" = "configure" ]; then
     CONF="elkarbackup"
+    CONFSSL="elkarbackup-ssl"
     COMMON_STATE=$(dpkg-query -f '${Status}' -W 'apache2.2-common' 2>/dev/null | awk '{print $3}' || true)
 
     if [ -e /usr/share/apache2/apache2-maintscript-helper ]; then
         # Jessie and Trusty
         . /usr/share/apache2/apache2-maintscript-helper
-        apache2_invoke enmod rewrite || exit $?
-        apache2_invoke enconf $CONF || exit $?
-        apache2_invoke ensite $CONF || exit $?
+        apache2_has_module rewrite || apache2_invoke enmod rewrite 2>/dev/null || exit $?
+	apache2_has_module ssl ||apache2_invoke enmod ssl 2>/dev/null || exit $?
+        apache2_invoke enconf $CONF 2>/dev/null || exit $?
+        apache2_invoke ensite $CONF 2>/dev/null || exit $?
+	apache2_invoke ensite $CONFSSL 2>/dev/null || exit $?
     elif [ "$COMMON_STATE" = "installed" ] || [ "$COMMON_STATE" = "unpacked" ] ; then
         # Ubuntu 12.04 (version module not enabled by default)
         if [ ! -f /etc/apache2/mods-enabled/version.load ]; then
@@ -163,16 +169,18 @@ if [ "$1" = "configure" ]; then
         fi
 
         if [ -d /etc/apache2/conf.d/ -a ! -L /etc/apache2/conf.d/$CONF.conf ]; then
+	    # Rename old files to Apache 2.4 format
             if [ -f /etc/apache2/conf.d/$CONF ]; then
                 mv /etc/apache2/conf.d/$CONF /etc/apache2/conf-available/$CONF.conf
             fi
-            #a2enconf
+       	    #a2enconf
             if [ ! -f /etc/apache2/conf.d/$CONF.conf ]; then
                 ln -s ../conf-available/$CONF.conf /etc/apache2/conf.d/$CONF.conf
 	    fi
         fi
 
         if [ -d /etc/apache2/sites-available/ -a ! -L /etc/apache2/sites-available/$CONF.conf ]; then
+	    # Rename old files to Apache 2.4 format
             if [ -f /etc/apache2/sites-available/$CONF ]; then
                 mv /etc/apache2/sites-available/$CONF /etc/apache2/sites-available/$CONF.conf
                 rm /etc/apache2/sites-enabled/$CONF
@@ -181,9 +189,13 @@ if [ "$1" = "configure" ]; then
 	    if [ ! -f /etc/apache2/sites-enabled/$CONF.conf ]; then
                 ln -s ../sites-available/$CONF.conf /etc/apache2/sites-enabled/$CONF.conf
 	    fi
+	    if [ ! -f /etc/apache2/sites-enabled/$CONFSSL.conf ]; then
+		ln -s ../sites-available/$CONFSSL.conf /etc/apache2/sites-enabled/$CONFSSL.conf
+	    fi
         fi
 
         a2enmod rewrite
+	a2enmod ssl
     fi
 fi
 

--- a/debian/DEBIAN/postrm
+++ b/debian/DEBIAN/postrm
@@ -12,15 +12,18 @@ fi
 
 if [ "$1" = "remove" ]; then
     CONF="elkarbackup"
+    CONFSSL="elkarbackup-ssl"
     COMMON_STATE=$(dpkg-query -f '${Status}' -W 'apache2.2-common' 2>/dev/null | awk '{print $3}' || true)
     
     if [ -e /usr/share/apache2/apache2-maintscript-helper ] ; then
         . /usr/share/apache2/apache2-maintscript-helper
         apache2_invoke disconf $CONF || exit $?
         apache2_invoke dissite $CONF || exit $?
+	apache2_invoke dissite $CONFSSL || exit $?
     elif [ "$COMMON_STATE" = "installed" ] || [ "$COMMON_STATE" = "unpacked" ] ; then
         [ ! -L /etc/apache2/conf.d/$CONF.conf ] || rm /etc/apache2/conf.d/$CONF.conf
         [ ! -L /etc/apache2/sites-enabled/$CONF.conf ] || rm /etc/apache2/sites-enabled/$CONF.conf
+	[ ! -L /etc/apache2/sites-enabled/$CONFSSL.conf ] || rm /etc/apache2/sites-enabled/$CONFSSL.conf
     fi
 
     deluser --system elkarbackup || echo "Problem deleting user elkarbackup"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,10 @@
-elkarbackup (1.2.0-Pre-Alpha2) UNRELEASED; urgency=medium
+elkarbackup (1.2.0-Pre-Alpha3) UNRELEASED; urgency=medium
 
-  * New Symfony 1.8 LTS (until Nov. 2018)
+  [ Xabi Ezpeleta ]
+  * Maintenance: New Symfony 1.8 LTS (until Nov. 2018)
   * Feature: Tahoe storage support
+  * Feature: HTTPS access enabled by default (fixes #98)
   * Bugfix: logger shows wrong message (fixes #114)
   * Bugfix: missing html tag (fixes #113)
 
- -- Xabi Ezpeleta <xezpeleta@gmail.com>  Tue, 15 Dec 2015 22:33:12 +0000
+ --  <xezpeleta@gmail.com>  Thu, 17 Dec 2015 19:35:04 +0000

--- a/debian/etc/apache2/sites-available/elkarbackup-ssl.conf
+++ b/debian/etc/apache2/sites-available/elkarbackup-ssl.conf
@@ -1,0 +1,25 @@
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    ServerName elkarbackup
+
+    DocumentRoot /usr/share/elkarbackup/web
+
+    <directory /usr/share/elkarbackup/web>
+        RewriteEngine On
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteRule ^(.*)$ app.php [QSA,L]
+        AllowOverride None
+    </directory>
+
+    SSLEngine on
+    SSLCertificateFile      /etc/ssl/certs/ssl-cert-snakeoil.pem
+    SSLCertificateKeyFile   /etc/ssl/private/ssl-cert-snakeoil.key
+
+    ErrorLog ${APACHE_LOG_DIR}/elkarbackup-ssl.error.log
+
+    # Possible values include: debug, info, notice, warn, error, crit,
+    # alert, emerg.
+    LogLevel warn
+
+    CustomLog ${APACHE_LOG_DIR}/elkarbackup-ssl.access.log combined
+</VirtualHost>

--- a/src/Binovo/ElkarBackupBundle/Resources/views/Default/login.html.twig
+++ b/src/Binovo/ElkarBackupBundle/Resources/views/Default/login.html.twig
@@ -78,7 +78,7 @@
                           </div>
                           <div class="row">
                             <div class="version pull-right">
-                              <p>v1.2.0-Pre-Alpha2</p>
+                              <p>v1.2.0-Pre-Alpha3</p>
                             </div>
                           </div>
                       </form>


### PR DESCRIPTION
This PR will:
* Enable HTTPS access
* Force Symfony cache cleaning during the installation (rm -fR /var/cache/elkarbackup/*) to avoid errors migrating to v1.2
* Hide annoying messages during the upgrade
* Increment version number to **v1.2-Pre-Alpha3**