### PR TITLE
Ignore parameters.yml and set right permissions for sessions directory

### DIFF
--- a/app/SymfonyRequirements.php
+++ b/app/SymfonyRequirements.php
@@ -447,6 +447,12 @@ class SymfonyRequirements extends RequirementCollection
         }
 
         $this->addRequirement(
+            function_exists('iconv'),
+            'iconv() must be available',
+            'Install and enable the <strong>iconv</strong> extension.'
+        );
+
+        $this->addRequirement(
             function_exists('json_encode'),
             'json_encode() must be available',
             'Install and enable the <strong>JSON</strong> extension.'
@@ -546,10 +552,10 @@ class SymfonyRequirements extends RequirementCollection
             require_once __DIR__.'/../vendor/autoload.php';
 
             try {
-                $r = new \ReflectionClass('Sensio\Bundle\DistributionBundle\SensioDistributionBundle');
+                $r = new ReflectionClass('Sensio\Bundle\DistributionBundle\SensioDistributionBundle');
 
                 $contents = file_get_contents(dirname($r->getFileName()).'/Resources/skeleton/app/SymfonyRequirements.php');
-            } catch (\ReflectionException $e) {
+            } catch (ReflectionException $e) {
                 $contents = '';
             }
             $this->addRecommendation(

--- a/app/config/parameters.yml
+++ b/app/config/parameters.yml
@@ -23,6 +23,6 @@ parameters:
     pagination_lines_per_page: 20
     url_prefix: null
     disable_background: false
+    mailer_from: null
     tahoe_active: false
     home: /var/lib/elkarbackup
-    mailer_from: null

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,9 +14,11 @@ fi
 
 mkdir -p app/cache
 mkdir -p app/logs
+mkdir -p app/sessions
 sudo setfacl  -R -m u:www-data:rwx -m u:elkarbackup:rwx -m u:$(id -un):rwx app/cache
 sudo setfacl -dR -m u:www-data:rwx -m u:elkarbackup:rwx -m u:$(id -un):rwx app/cache
 sudo setfacl  -R -m u:www-data:rwx -m u:elkarbackup:rwx -m u:$(id -un):rwx app/logs
 sudo setfacl -dR -m u:www-data:rwx -m u:elkarbackup:rwx -m u:$(id -un):rwx app/logs
-
+sudo setfacl  -R -m u:www-data:rwx -m u:elkarbackup:rwx -m u:$(id -un):rwx app/sessions
+sudo setfacl -dR -m u:www-data:rwx -m u:elkarbackup:rwx -m u:$(id -un):rwx app/sessions
 composer install --no-interaction


### PR DESCRIPTION
This PR will:
* Update SymfonyRequirements.php to the last Symfony 2.8
* Modify bootstrap.sh script to create sessions directory with right permissions
* Ignore parameters.yml in Git (it will use parameters.yml.dist instead)