### PR TITLE
Customize  SSH args into the Client advanced configuration (#87)

### DIFF
--- a/app/DoctrineMigrations/Version20160103215703.php
+++ b/app/DoctrineMigrations/Version20160103215703.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160103215703 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Client ADD sshArgs VARCHAR(255) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Client DROP sshArgs');
+    }
+}

--- a/src/Binovo/ElkarBackupBundle/Entity/Client.php
+++ b/src/Binovo/ElkarBackupBundle/Entity/Client.php
@@ -81,6 +81,13 @@ class Client
      */
     protected $owner;
 
+    /**
+     * Rsnapshot ssh_args parameter
+     *
+     * @ORM\Column(type="string",length=255, nullable=true)
+     */
+    protected $sshArgs;
+
 
 
     /**
@@ -391,5 +398,29 @@ class Client
     public function getOwner()
     {
         return $this->owner;
+    }
+
+    /**
+     * Set sshArgs
+     *
+     * @param string $sshArgs
+     *
+     * @return Client
+     */
+    public function setSshArgs($sshArgs = null)
+    {
+        $this->sshArgs = $sshArgs;
+
+        return $this;
+    }
+
+    /**
+     * Get sshArgs
+     *
+     * @return string
+     */
+    public function getSshArgs()
+    {
+        return $this->sshArgs;
     }
 }

--- a/src/Binovo/ElkarBackupBundle/Entity/Job.php
+++ b/src/Binovo/ElkarBackupBundle/Entity/Job.php
@@ -643,10 +643,14 @@ class Job
      */
     public function getSshArgs()
     {
+	// Do not allow ssh_args in the URL
+	/*
         $clientUrl = $this->client->getUrl();
         if (strpos($clientUrl, 'ssh_args') !== false) {
           $args = explode("ssh_args=", $clientUrl)[1];
           return $args;
         }
+	*/
+	return $this->client->getSshArgs();
     }
 }

--- a/src/Binovo/ElkarBackupBundle/Form/Type/ClientType.php
+++ b/src/Binovo/ElkarBackupBundle/Form/Type/ClientType.php
@@ -67,6 +67,8 @@ class ClientType extends AbstractType
                                                                 'property' => 'username',
                                                                 'attr'     => array('class'    => 'form-control'),
                                                                 'class'    => 'BinovoElkarBackupBundle:User'))
+                ->add('sshArgs'	      , 'text'      , array('label' => $t->trans('SSH args', array(), 'BinovoElkarBackup'),
+                                                            'attr'  => array('class'     => 'form-control advanced-form-item')))
                 ->add('jobs'          , 'collection', array('type'         => new JobShortType(),
                                                             'allow_delete' => true,
                                                             'label'        => $t->trans('Jobs', array(), 'BinovoElkarBackup')));

--- a/src/Binovo/ElkarBackupBundle/Resources/public/css/elkarbackup.css
+++ b/src/Binovo/ElkarBackupBundle/Resources/public/css/elkarbackup.css
@@ -621,3 +621,18 @@ CLIENTS-TASKS
 {
 display:none;
 }
+
+
+.client-advanced-section{
+  margin-bottom: 10px !important;  
+}
+
+.dijitTitlePaneTitleActive{
+  background-color: #2D3F50 !important;
+  border-color: #759DC0 !important;
+}
+
+.dijitTitlePaneTitleHover{
+  background-color: #3B5269 !important;
+  border-color: #759DC0 !important;
+}

--- a/src/Binovo/ElkarBackupBundle/Resources/public/js/edit-client.js
+++ b/src/Binovo/ElkarBackupBundle/Resources/public/js/edit-client.js
@@ -2,8 +2,8 @@
  * @copyright 2012,2013 Binovo it Human Project, S.L.
  * @license http://www.opensource.org/licenses/bsd-license.php New-BSD
  */
-require(['dojo', 'dojo/ready', 'dojox/form/CheckedMultiSelect' ],
-function(dojo, ready){
+require(['dojo', 'dojo/ready', 'dojox/form/CheckedMultiSelect', 'dijit/TitlePane', 'dojo/parser' ],
+function(dojo, ready, TitlePane, dom){
     ready(function() {
               dojo.query('.delete-job')
                   .connect('onclick',

--- a/src/Binovo/ElkarBackupBundle/Resources/views/Default/client.html.twig
+++ b/src/Binovo/ElkarBackupBundle/Resources/views/Default/client.html.twig
@@ -47,6 +47,10 @@
             {% if is_granted('ROLE_ADMIN') %}
                 {{ form_row(form.owner) }}
             {% endif %}
+	<div id="tp" class="client-advanced-section" data-dojo-type="dijit/TitlePane" data-dojo-props="title: 'Advanced:'">
+	    {{ form_row(form.sshArgs) }}
+        </div>
+
 
             <div class="control-group">
               <div class="controls control-row">


### PR DESCRIPTION
This PR adds the possibility to customize the Rsnapshot "ssh-args" parameter directly from the Client configuration form.

Screenshots:
![screenshot from 2016-01-07 15-04-28](https://cloud.githubusercontent.com/assets/1846038/12172237/03532c72-b550-11e5-9b14-d2ac8ecd439a.png)
![screenshot from 2016-01-07 15-04-43](https://cloud.githubusercontent.com/assets/1846038/12172241/05bc9fe8-b550-11e5-9074-beeeac7ae323.png)
