### PR TITLE
Remove "Owner" field from Job edition form (Fixes #139)

### DIFF
--- a/app/DoctrineMigrations/Version20160429134626.php
+++ b/app/DoctrineMigrations/Version20160429134626.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160429134626 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Job DROP FOREIGN KEY FK_C395A6187E3C61F9');
+        $this->addSql('DROP INDEX IDX_C395A6187E3C61F9 ON Job');
+        $this->addSql('ALTER TABLE Job DROP owner_id');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE Job ADD owner_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE Job ADD CONSTRAINT FK_C395A6187E3C61F9 FOREIGN KEY (owner_id) REFERENCES User (id)');
+        $this->addSql('CREATE INDEX IDX_C395A6187E3C61F9 ON Job (owner_id)');
+    }
+}

--- a/src/Binovo/ElkarBackupBundle/Controller/DefaultController.php
+++ b/src/Binovo/ElkarBackupBundle/Controller/DefaultController.php
@@ -416,15 +416,13 @@ class DefaultController extends Controller
                 throw $this->createNotFoundException($this->trans('Unable to find Client entity:') . $idClient);
             }
             $job->setClient($client);
-            $job->setOwner($this->get('security.context')->getToken()->getUser());
         } else {
-	    $access = $this->checkPermissions($idClient, $idJob);
-                if($access == True){
-                	$job = $this->getDoctrine()
-                                ->getRepository('BinovoElkarBackupBundle:Job')->find($idJob);
-
-                } else {return $this->redirect($this->generateUrl('showClients'));}
-
+	          $access = $this->checkPermissions($idClient, $idJob);
+            if($access == True){
+                $job = $this->getDoctrine()->getRepository('BinovoElkarBackupBundle:Job')->find($idJob);
+            } else {
+                return $this->redirect($this->generateUrl('showClients'));
+            }
         }
         $form = $this->createForm(new JobType(), $job, array('translator' => $this->get('translator')));
         $this->info('View client %clientid%, job %jobid%',
@@ -670,17 +668,10 @@ class DefaultController extends Controller
                 ->getRepository('BinovoElkarBackupBundle:Job');
             $job = $repository->find($idJob);
         }
-        $storedOwner = $job->getOwner();
         $form = $this->createForm(new JobType(), $job, array('translator' => $t));
         $form->bind($request);
         if ($form->isValid()) {
             $job = $form->getData();
-//            if (!$this->get('security.context')->isGranted('ROLE_ADMIN')) { // only allow chown to admin
-//                $job->setOwner($storedOwner);
-//            }
-            if ($job->getOwner() == null) {
-                $job->setOwner($this->get('security.context')->getToken()->getUser());
-            }
             try {
                 $em = $this->getDoctrine()->getManager();
                 $em->persist($job);

--- a/src/Binovo/ElkarBackupBundle/Entity/Job.php
+++ b/src/Binovo/ElkarBackupBundle/Entity/Job.php
@@ -71,11 +71,6 @@ class Job
     protected $minNotificationLevel = self::NOTIFICATION_LEVEL_ERROR;
 
     /**
-     * @ORM\ManyToOne(targetEntity="User")
-     */
-    protected $owner;
-
-    /**
      * Include expressions
      * @ORM\Column(type="text", nullable=true)
      */
@@ -136,13 +131,13 @@ class Job
     protected $logEntry = null;
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type="string", length=255, nullable=true)
      * Job status: running, queued, failed, aborting, aborted
      */
     protected $status = null;
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type="string", length=255, nullable=true)
      * Security token for remote management
      */
     protected $token = null;
@@ -393,29 +388,6 @@ class Job
     public function getIsActive()
     {
         return $this->isActive;
-    }
-
-    /**
-     * Set owner
-     *
-     * @param Binovo\ElkarBackupBundle\Entity\User $owner
-     * @return Job
-     */
-    public function setOwner(User $owner)
-    {
-        $this->owner = $owner;
-
-        return $this;
-    }
-
-    /**
-     * Get owner
-     *
-     * @return Binovo\ElkarBackupBundle\Entity\User
-     */
-    public function getOwner()
-    {
-        return $this->owner;
     }
 
 

--- a/src/Binovo/ElkarBackupBundle/Form/Type/JobType.php
+++ b/src/Binovo/ElkarBackupBundle/Form/Type/JobType.php
@@ -34,17 +34,13 @@ class JobType extends AbstractType
                 ->add('include'             , 'textarea', array('label' => $t->trans('Include', array(), 'BinovoElkarBackup'),
                                                                 'required' => false,
                                                                 'attr' => array('class'    => 'form-control','rows' => '3')))
-                ->add('owner'               , 'entity'  , array('label'    => $t->trans('Owner', array(), 'BinovoElkarBackup'),
-                                                                'property' => 'username',
-                                                                'attr'     => array('class'    => 'form-control'),
-                                                                'class'    => 'BinovoElkarBackupBundle:User'))
                 ->add('path'                , 'text'    , array('label' => $t->trans('Path', array(), 'BinovoElkarBackup'),
                                                                 'attr'  => array('class'    => 'form-control')))
                 ->add('notificationsTo'     , 'choice'  , array('label'    => $t->trans('Send notices to', array(), 'BinovoElkarBackup'),
                                                                 'required' => false,
                                                                 'attr'     => array('class'    => 'form-control-no'),
                                                                 'choices'  => array(Job::NOTIFY_TO_ADMIN => $t->trans('Admin', array(), 'BinovoElkarBackup'),
-                                                                                    Job::NOTIFY_TO_OWNER => $t->trans('Owner', array(), 'BinovoElkarBackup'),
+                                                                                    Job::NOTIFY_TO_OWNER => $t->trans('Client owner', array(), 'BinovoElkarBackup'),
                                                                                     Job::NOTIFY_TO_EMAIL => $t->trans('Email', array(), 'BinovoElkarBackup')),
                                                                 'multiple' => true,
                                                                 'expanded' => true,))

--- a/src/Binovo/ElkarBackupBundle/Lib/BackupRunningCommand.php
+++ b/src/Binovo/ElkarBackupBundle/Lib/BackupRunningCommand.php
@@ -74,7 +74,7 @@ abstract class BackupRunningCommand extends LoggingCommand
                     $recipients[] = $adminEmail;
                     break;
                 case Job::NOTIFY_TO_OWNER:
-                    $recipients[] = $job->getOwner()->getEmail();
+                    $recipients[] = $job->getClient()->getOwner()->getEmail();
                     break;
                 case Job::NOTIFY_TO_EMAIL:
                     $recipients[] = $job->getNotificationsEmail();
@@ -330,7 +330,7 @@ abstract class BackupRunningCommand extends LoggingCommand
             $errScriptOk      = 'Job "%entityid%" %scripttype% script "%scriptname%" execution succeeded. Output follows: %output%';
             $level            = 'JOB';
             $job_name         = $job->getName();
-            $owner_email      = $job->getOwner()->getEmail();
+            $owner_email      = $job->getClient()->getOwner()->getEmail();
             $recipient_list   = $job->getNotificationsEmail();
             $job_total_size   = $job->getDiskUsage();
             $client_starttime = 0;

--- a/src/Binovo/ElkarBackupBundle/Resources/translations/BinovoElkarBackup.en.yml
+++ b/src/Binovo/ElkarBackupBundle/Resources/translations/BinovoElkarBackup.en.yml
@@ -331,8 +331,6 @@ job_help: |
  Free text to describe the job. Put here whatever you might find useful.
  <h4>Is active</h4>
  If this check box is not marked, then no snapshots will be taken.
- <h4>Owner</h4>
- By default the user who created the job is the owner and the application will notify him of any problems (see send notices to and notify only). Only admin users can change the owner.
  <h4>Send notices to</h4>
  You can ask the application to notify one or several of the following people (by email) of any events. The application decides which events to notify based on the notify only settings. If you choose to notify an arbitrary email you will have to fill in that email address.
  <h4>Notify only</h4>

--- a/src/Binovo/ElkarBackupBundle/Resources/views/Default/job.html.twig
+++ b/src/Binovo/ElkarBackupBundle/Resources/views/Default/job.html.twig
@@ -60,7 +60,6 @@
                 </div>
                 {{ form_row(form.description) }}
                 {{ form_row(form.isActive) }}
-                {{ form_row(form.owner, {read_only: not is_granted('ROLE_ADMIN')}) }}
                 {{ form_row(form.notificationsTo) }}
                 {{ form_row(form.notificationsEmail, {attr: {class: 'col-md-12'}}) }}
                 {{ form_row(form.minNotificationLevel) }}


### PR DESCRIPTION
This PR removes "Owner" field from Job edition form and changes the "owner" checkbox to use "Client owner" instead.

More info: #139 