### PR TITLE
Do not treat Rsnapshot exit value 2 as error

### DIFF
--- a/src/Binovo/ElkarBackupBundle/Lib/BackupRunningCommand.php
+++ b/src/Binovo/ElkarBackupBundle/Lib/BackupRunningCommand.php
@@ -204,7 +204,7 @@ abstract class BackupRunningCommand extends LoggingCommand
                 $status        = 0;
                 $this->info('Running %command%', array('%command%' => $command), $context);
                 exec($command, $commandOutput, $status);
-                if (0 != $status) {
+                if (0 != $status || 2 != $status) {
                     $this->err('Command %command% failed. Diagnostic information follows: %output%',
                                array('%command%' => $command,
                                      '%output%'  => "\n" . implode("\n", $commandOutput)),

--- a/src/Binovo/ElkarBackupBundle/Lib/BackupRunningCommand.php
+++ b/src/Binovo/ElkarBackupBundle/Lib/BackupRunningCommand.php
@@ -204,7 +204,7 @@ abstract class BackupRunningCommand extends LoggingCommand
                 $status        = 0;
                 $this->info('Running %command%', array('%command%' => $command), $context);
                 exec($command, $commandOutput, $status);
-                if (0 != $status || 2 != $status) {
+                if (1 == $status) {
                     $this->err('Command %command% failed. Diagnostic information follows: %output%',
                                array('%command%' => $command,
                                      '%output%'  => "\n" . implode("\n", $commandOutput)),
@@ -379,7 +379,7 @@ abstract class BackupRunningCommand extends LoggingCommand
                                  $client->getSshArgs(),
                                  $scriptFile);
         exec($command, $commandOutput, $status);
-        if (0 != $status) {
+        if (1 == $status) {
             $this->err($errScriptError,
                        array('%entityid%'   => $entity->getId(),
                              '%output%'     => "\n" . implode("\n", $commandOutput),


### PR DESCRIPTION
El código de salida de rsnapshot con número 2 no necesariamente es un comando fallido, solo es un comando success pero con warnings.

Tal vez sea necesario agregar una leyenda en el status de los Jobs como "WARN", pero por lo pronto sería bueno marcarlo como SUCCESS, ya que solo hay WARNING si el pre y post script falla.