### PR TITLE
Change status from ABORTING to ABORTED if the lockfile has been deleted

### DIFF
--- a/src/Binovo/ElkarBackupBundle/Command/StopJobCommand.php
+++ b/src/Binovo/ElkarBackupBundle/Command/StopJobCommand.php
@@ -76,7 +76,13 @@
                             'source' => Globals::STATUS_REPORT);
            $job->setStatus('ABORTED');
         } else {
-           $this->warn('Cannot abort job backup: not running', array(), $context);
+           if ($job->getStatus() == "ABORTING"){
+              // Avoid endless Aborting status
+              $job->setStatus('ABORTED');
+              $this->warn('Job already aborted', array(), $context);
+           } else {
+              $this->warn('Cannot abort job backup: not running', array(), $context);
+           }
         }
     }
 


### PR DESCRIPTION
Algunas veces cuando rsnapshot sale con status code diferente (ejemplo 2) o por algun error, el mismo rsnapshot borra el pid file o $lockfile y al poner "ABORT" el status queda siempre en "ABORTING" y nunca cambia, este fix resuelve que si no esta el $lockfile y tenemos el status de "ABORTING", asignemos el status de ABORTED, ya que el Job ya fue detenido con anterioridad.

Ejemplo de salida de rsnapshot:
touch /var/spool/elkarbackup/backups/0002/0011/Weekly.0/
rm -f /tmp/rsnapshot.0002_0011.pid
/usr/bin/logger -p user.info -t rsnapshot[4594] /usr/bin/rsnapshot -c \
    rsnapshot.2_11.cfg Weekly: completed successfully