### PR TITLE
Do not follow/download symlinks

### DIFF
--- a/src/Binovo/ElkarBackupBundle/Controller/DefaultController.php
+++ b/src/Binovo/ElkarBackupBundle/Controller/DefaultController.php
@@ -775,7 +775,7 @@ class DefaultController extends Controller
                 foreach ($content as &$aFile) {
                     $date = new \DateTime();
                     $date->setTimestamp(filemtime($realPath . '/' . $aFile));
-                    $aFile = array($aFile, $date, is_dir($realPath . '/' . $aFile));
+                    $aFile = array($aFile, $date, is_dir($realPath . '/' . $aFile), is_link($realPath . '/' . $aFile));
                 }
                 $this->info('View backup directory %clientid%, %jobid% %path%',
                             array('%clientid%' => $idClient,

--- a/src/Binovo/ElkarBackupBundle/Resources/views/Default/directory.html.twig
+++ b/src/Binovo/ElkarBackupBundle/Resources/views/Default/directory.html.twig
@@ -33,8 +33,11 @@
 		<tr>
 
 		    <td>
-
-          {% if file.2 %}
+          {% if file.3 %}
+            {# It's a symlink #}
+            <span class="glyphicon glyphicon-link"></span>&nbsp;{{ file.0 }}
+          {% elseif file.2 %}
+            {# It's a directory #}
 		        <a href="{{ path('showJobBackup', {idClient: job.client.id, idJob: job.id , path: path  ~ file.0 ~ '/' , action: 'view'}) }}">
 			           <span class="glyphicon glyphicon-folder-open"></span>
                  &nbsp;{{ file.0 }}
@@ -48,7 +51,7 @@
 		        {{ file.1.format('Y-m-d H:i:s') }}
 		    </td>
 		    <td>
-		        {% if file.0 != ".." and file.0 != "." %}
+		        {% if file.0 != ".." and file.0 != "." and file.3 == false %}
 
               {% if file.2 %}
                 <a href="{{ path('showJobBackup', {idClient: job.client.id, idJob: job.id, path: path ~ '/' ~ file.0, action: 'download'}) }}"><b>


### PR DESCRIPTION
This PR fixes issue #159 .

Browsing a directory, if there is a symlink, it hiddes the option to follow it / download it.