### PR TITLE
Change password fields from required to optional

### DIFF
--- a/src/Binovo/ElkarBackupBundle/Form/Type/UserType.php
+++ b/src/Binovo/ElkarBackupBundle/Form/Type/UserType.php
@@ -17,7 +17,7 @@ class UserType extends AbstractType
         $t = $options['translator'];
         $builder->add('username'    , 'text'    , array('label' => $t->trans('Name'     , array(), 'BinovoElkarBackup'),
                                                         'attr'  => array('class'    => 'form-control')))
-	              ->add('email'       , 'email'   , array('label' => $t->trans('Email'    , array(), 'BinovoElkarBackup'),
+                ->add('email'       , 'email'   , array('label' => $t->trans('Email'    , array(), 'BinovoElkarBackup'),
                                                         'attr'  => array('class'    => 'form-control')))
                 ->add('isActive'    , 'checkbox', array('label' => $t->trans('Is active', array(), 'BinovoElkarBackup'),
                                                         'required' => false))

--- a/src/Binovo/ElkarBackupBundle/Form/Type/UserType.php
+++ b/src/Binovo/ElkarBackupBundle/Form/Type/UserType.php
@@ -15,24 +15,13 @@ class UserType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $t = $options['translator'];
-/*        $builder->add('username'    , 'text'    , array('label' => $t->trans('Name'     , array(), 'BinovoElkarBackup'),
+        $builder->add('username'    , 'text'    , array('label' => $t->trans('Name'     , array(), 'BinovoElkarBackup'),
                                                         'attr'  => array('class'    => 'form-control')))
-                ->add('newPassword' , 'password', array('label' => $t->trans('Password' , array(), 'BinovoElkarBackup'),
-                                                        'required' => false,
-                                                        'attr'  => array('class'    => 'form-control')))
-                ->add('email'       , 'email'   , array('label' => $t->trans('Email'    , array(), 'BinovoElkarBackup'),
+	              ->add('email'       , 'email'   , array('label' => $t->trans('Email'    , array(), 'BinovoElkarBackup'),
                                                         'attr'  => array('class'    => 'form-control')))
                 ->add('isActive'    , 'checkbox', array('label' => $t->trans('Is active', array(), 'BinovoElkarBackup'),
-                                                        'required' => false));
-*/
-
-$builder->add('username'    , 'text'    , array('label' => $t->trans('Name'     , array(), 'BinovoElkarBackup'),
-                                                        'attr'  => array('class'    => 'form-control')))
-	->add('email'       , 'email'   , array('label' => $t->trans('Email'    , array(), 'BinovoElkarBackup'),
-                                                        'attr'  => array('class'    => 'form-control')))
-        ->add('isActive'    , 'checkbox', array('label' => $t->trans('Is active', array(), 'BinovoElkarBackup'),
                                                         'required' => false))
-        ->add('roles'      , 'collection', array('type' => 'choice',
+                ->add('roles'      , 'collection', array('type' => 'choice',
                                              //'label' => 'Profile type',
                                              //'attr' => array('class' => 'form-control'),
                                              'options' => array(
@@ -43,16 +32,13 @@ $builder->add('username'    , 'text'    , array('label' => $t->trans('Name'     
                                                 ),
                                              ),
                                           ))
-
-
-	->add('newPassword', 'repeated', array('type' => 'password',
-			     'options' => array('attr' => array('class' => 'password-field form-control')),
-			     'required' => true,
-			     'first_options'  => array('label' => $t->trans('New password' , array(), 'BinovoElkarBackup')),
-			     'second_options' => array('label' => $t->trans('Confirm new password', array(), 'BinovoElkarBackup')),
-    			     'invalid_message' => 'The password fields must match.',
-
-				));
+                ->add('newPassword', 'repeated', array('type' => 'password',
+			                                                 'options' => array('attr' => array('class' => 'password-field form-control')),
+			                                                 'required' => false,
+			                                                 'first_options'  => array('label' => $t->trans('New password' , array(), 'BinovoElkarBackup')),
+			                                                 'second_options' => array('label' => $t->trans('Confirm new password', array(), 'BinovoElkarBackup')),
+    			                                             'invalid_message' => 'The password fields must match.'
+                     ));
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Binovo/ElkarBackupBundle/Resources/public/css/elkarbackup.css
+++ b/src/Binovo/ElkarBackupBundle/Resources/public/css/elkarbackup.css
@@ -525,7 +525,7 @@ table.dijit.dijitMenu.menu_level_1 tbody tr td a {
   left: 50%;
   position: absolute;
   text-align: center;
-  top: -99px;
+  top: -59px;
   width: 60%;
 }
 


### PR DESCRIPTION
This PR makes optional the passwords fields under the user edition. In this way, we can now edit any other field (i.e. email address) without type/change the password.

Related issue: #210 