### PR TITLE
Migration modified to migrate correctly backup_dir param.

### DIFF
--- a/app/DoctrineMigrations/Version20180207095757.php
+++ b/app/DoctrineMigrations/Version20180207095757.php
@@ -4,12 +4,17 @@ namespace Application\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-class Version20180207095757 extends AbstractMigration
+class Version20180207095757 extends AbstractMigration implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+    
     /**
      * @param Schema $schema
      */
@@ -17,12 +22,29 @@ class Version20180207095757 extends AbstractMigration
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
-
+        
         $this->addSql('CREATE TABLE BackupLocation (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, host VARCHAR(255), directory VARCHAR(255) NOT NULL, tahoe TINYINT(1) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
-        $this->addSql('ALTER TABLE Job ADD backupLocation_id INT DEFAULT NULL');
-        $this->addSql('ALTER TABLE Job ADD CONSTRAINT FK_C395A618615D27E1 FOREIGN KEY (backupLocation_id) REFERENCES BackupLocation (id)');
+        $this->addSql('ALTER TABLE Job ADD backupLocation_id INT NOT NULL');
         $this->addSql('CREATE INDEX IDX_C395A618615D27E1 ON Job (backupLocation_id)');
-        $this->addSql("INSERT INTO BackupLocation VALUES(1,'Default','','/var/spool/elkarbackup/backups',0)");
+        
+        //get backup_dir param and store as new BackupLocation
+        if ($this->container->hasParameter('backup_dir')) {
+            $location = $this->container->getParameter('backup_dir');
+            $this->addSql("INSERT INTO BackupLocation VALUES(1,'Default','','" . $location . "',0)");
+            
+            $rootDir = $this->container->get('kernel')->getRootDir();
+            $paramsDir = $rootDir . "/config/parameters.yml";
+            $value = Yaml::parse(file_get_contents($paramsDir));
+            unset($value['parameters']['backup_dir']);
+            $yaml = Yaml::dump($value);
+            file_put_contents($paramsDir, $yaml);
+            
+        } else {
+            $this->addSql("INSERT INTO BackupLocation VALUES(1,'Default','', '/var/spool/elkarbackup/backups',0)");
+        }
+        $this->addSql("UPDATE Job SET backupLocation_id=1");
+        $this->addSql('ALTER TABLE Job ADD CONSTRAINT FK_C395A618615D27E1 FOREIGN KEY (backupLocation_id) REFERENCES BackupLocation (id)');
+        
     }
 
     /**


### PR DESCRIPTION
This PR solves #282 issue.

The param value from _backup_dir_ is moved to the new Backup Location entity and removed from _parameters.yml_.

This way the parameter will be correctly moved to the database if the default directory had changed. If there is no _backup_dir_ param, a new Backup Location entity will be created with default values.

Anyway, the created Backup Location entity will be assigned to all jobs.