### PR TITLE
Added message when trying to queue same job multiple times.

### DIFF
--- a/src/Binovo/ElkarBackupBundle/Controller/DefaultController.php
+++ b/src/Binovo/ElkarBackupBundle/Controller/DefaultController.php
@@ -645,26 +645,31 @@ class DefaultController extends Controller
                 $status = 'QUEUED';
                 $queue = new Queue($job);
                 $em->persist($queue);
-                $response = new Response($t->trans(
-                    'Job execution requested successfully',
-                    array(),
-                    'BinovoElkarBackup'
+                $response = new JsonResponse(array(
+                    'error' => false,
+                    'msg' => $t->trans(
+                        'Job queued successfully. It will start running in less than a minute!',
+                        array(),
+                        'BinovoElkarBackup'
+                        ),
+                    'data' => array($idJob)
                 ));
                 $this->info($status, array(), $context);
                 
             } else {
                 $status = 'The job has been already enqueued, it will not be enqueued again';
-                $response = new Response($t->trans(
-                    'One or more jobs were already enqueued, they will not be enqueued again',
-                    array(),
-                    'BinovoElkarBackup'
+                $response = new JsonResponse(array(
+                    'error' => true,
+                    'msg' => $t->trans(
+                        'One or more jobs were already enqueued, they will not be enqueued again',
+                        array(),
+                        'BinovoElkarBackup'
+                        ),
+                    'data' => array($idJob)
                 ));
                 $this->warn($status, array(), $context);
             }
             $em->flush();
-            $response->headers->set('Content-Type', 'text/plain');
-            // TODO: change the response from text plain to JSON
-
             return $response;
         }
     }

--- a/src/Binovo/ElkarBackupBundle/Resources/public/js/show-clients.js
+++ b/src/Binovo/ElkarBackupBundle/Resources/public/js/show-clients.js
@@ -443,7 +443,6 @@ $(document).ready(function(){
             if (!disabled){
               if (enqueueJob(path, jobid)){
                 // msg should be received from controller (translated)
-                okMsg('Job queued successfully. It will start running in less than a minute!');
               } else {
                 errorMsg('Error running job');
               }


### PR DESCRIPTION
This PR solves the log message that wrote 'QUEUED' multiple times when queuing a job. Now, when the job is queued multiple times, it shows a warning message. #294