### PR TITLE
Fix logrorate permissions issue (#279)

### DIFF
--- a/debian/DEBIAN/postinst
+++ b/debian/DEBIAN/postinst
@@ -141,13 +141,21 @@ then
     sed -i "s#public_key:.*#public_key: /var/lib/elkarbackup/.ssh/id_rsa.pub#" /etc/elkarbackup/parameters.yml
     chown -R $username.$username /var/lib/elkarbackup
 fi
+
+# let's create /var/log/elkarbackup/jobs directory (it should be already created)
+if [ ! -d /var/log/elkarbackup/jobs ]
+then
+    mkdir -p /var/log/elkarbackup/jobs
+fi
+
 # set rwx permissions for www-data and the backup user in the cache and log directories
 # as described in http://symfony.com/doc/current/book/installation.html#configuration-and-setup
 setfacl  -R -m u:www-data:rwx -m u:$username:rwx /var/cache/elkarbackup 2>/dev/null || ( echo "ACLs not supported. Remount with ACL and reconfigure with 'dpkg --configure --pending'" && false )
 setfacl -dR -m u:www-data:rwx -m u:$username:rwx /var/cache/elkarbackup 2>/dev/null
 setfacl  -R -m u:www-data:rwx -m u:$username:rwx /var/log/elkarbackup 2>/dev/null
 setfacl -dR -m u:www-data:rwx -m u:$username:rwx /var/log/elkarbackup 2>/dev/null
-chown -R $username.$username /var/cache/elkarbackup /var/log/elkarbackup /var/spool/elkarbackup
+chown -R $username.$username /var/cache/elkarbackup /var/spool/elkarbackup
+chown -R $username.root /var/log/elkarbackup
 chown -R www-data.www-data /var/lib/elkarbackup/sessions /etc/elkarbackup/parameters.yml /var/spool/elkarbackup/uploads
 
 uploadsdir="/var/spool/elkarbackup/uploads"

--- a/makepackage.sh
+++ b/makepackage.sh
@@ -44,6 +44,7 @@ rm .debian/usr/share/elkarbackup/web/.htaccess
 # setup cache, session and log directories in var
 mkdir -p .debian/var/cache/elkarbackup
 mkdir -p .debian/var/log/elkarbackup
+mkdir -p .debian/var/log/elkarbackup/jobs
 mkdir -p .debian/var/lib/elkarbackup/sessions
 ln -s /var/cache/elkarbackup        .debian/usr/share/elkarbackup/app/cache
 ln -s /var/log/elkarbackup          .debian/usr/share/elkarbackup/app/logs


### PR DESCRIPTION
The error was caused by an incorrect permissions in log directories. Changing the group to "root" solves the error.

By the way, now I make sure the directory `/var/log/elkarbackup/jobs` will be created in post-installation stage.