### PR TITLE
Fix Travis-CI configuration: services mysql required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 php:
 #  - 5.3  # Debian Squeeze => NOT SUPPORTED
 #  - 5.4  # Debian Wheezy  => NOT SUPPORTED
-  - 5.5  # Ubuntu Trusty
+#  - 5.5  # Ubuntu Trusty
   - 5.6  # Debian Jessie
   - 7.0  # Debian Stretch / Ubuntu Xenial
   - 7.1  # Ubuntu Bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+services:
+  - mysql
+
 php:
 #  - 5.3  # Debian Squeeze => NOT SUPPORTED
 #  - 5.4  # Debian Wheezy  => NOT SUPPORTED


### PR DESCRIPTION
This PR changes Travis-CI configuration:
- `services: mysql` is now required
- PHP5.5 is not available anymore with `dist=xenial`. I've disabled it temporarily, until I find a better solution.