### PR TITLE
Fix incorrect call to getEffectiveDir method (#323)

### DIFF
--- a/src/Binovo/ElkarBackupBundle/Controller/DefaultController.php
+++ b/src/Binovo/ElkarBackupBundle/Controller/DefaultController.php
@@ -931,7 +931,7 @@ class DefaultController extends Controller
                 . $idClient . " " . $idJob
             );
         }
-        $backupDir = $job->getEffectiveDir();
+        $backupDir = $job->getBackupLocation()->getEffectiveDir();
         $client = $job->getClient();
         $logDir = $this->container->get('kernel')->getLogDir();
         $tmpDir = $this->container->getParameter('tmp_dir');


### PR DESCRIPTION
This PR solves the 500 internal server error in "/client/<id>/job/<id>/config"