### PR TITLE
Run all the runnable retains for scheduled jobs

### DIFF
--- a/src/Binovo/ElkarBackupBundle/Command/RunJobCommand.php
+++ b/src/Binovo/ElkarBackupBundle/Command/RunJobCommand.php
@@ -344,7 +344,7 @@ class RunJobCommand extends LoggingCommand
         ->findOneBy(array('job' => $job));
         
         if (null == $queue) {
-            // This sould not happen
+            // This should not happen
             return $runnableRetains;
         }
         $time = $queue->getDate();

--- a/src/Binovo/ElkarBackupBundle/Command/RunJobCommand.php
+++ b/src/Binovo/ElkarBackupBundle/Command/RunJobCommand.php
@@ -15,7 +15,7 @@ class RunJobCommand extends LoggingCommand
     {
         parent::configure();
         $this->setName('elkarbackup:run_job')
-            ->setDescription('Runs specified job. Runs the lowest of all retains (the one that actually syncs)')
+            ->setDescription('Runs specified job (must be in the queue). Runs all pending retains')
             ->addArgument('job', InputArgument::REQUIRED, 'The ID of the job.');
     }
 

--- a/src/Binovo/ElkarBackupBundle/Command/RunJobCommand.php
+++ b/src/Binovo/ElkarBackupBundle/Command/RunJobCommand.php
@@ -344,12 +344,18 @@ class RunJobCommand extends LoggingCommand
         ->findOneBy(array('job' => $job));
         
         if (null == $queue) {
-            // This should not happen
+            // This should not happen, job must be in the queue!
             return $runnableRetains;
         }
         $time = $queue->getDate();
         $policy = $job->getPolicy();
         $runnableRetains = $policy->getRunnableRetains($time);
+        if (count($runnableRetains) == 0){
+            // Job has been enqueued on demand, not scheduled
+            // We will run the lowest of all retains (the one that actually syncs)
+            $retains = $policy->getRetains();
+            $runnableRetains = array($retains[0][0]);
+        }
         return $runnableRetains;
     }
 

--- a/src/Binovo/ElkarBackupBundle/Command/RunJobCommand.php
+++ b/src/Binovo/ElkarBackupBundle/Command/RunJobCommand.php
@@ -47,6 +47,12 @@ class RunJobCommand extends LoggingCommand
                 return self::ERR_CODE_NO_ACTIVE_RETAINS;
             }
             $retainsToRun = $this->getRunnableRetains($job);
+            if (count($retainsToRun) == 0) {
+                $this->warn('Job %jobid% not found in queue', array('%jobid%' => $jobId));
+                //Return unknown error code because this shouldn't happen
+                return self::ERR_CODE_UNKNOWN;
+            }
+            
             $result = $this->runJob($job, $retainsToRun);
             $manager->flush();
             
@@ -338,11 +344,7 @@ class RunJobCommand extends LoggingCommand
         ->findOneBy(array('job' => $job));
         
         if (null == $queue) {
-            $this->warn(
-                'Job not found in queue!',
-                array(),
-                $context
-            );
+            // This sould not happen
             return $runnableRetains;
         }
         $time = $queue->getDate();


### PR DESCRIPTION
This PR fixes the issue #326 

It modifies the RunJobCommand, which was initially designed to run -only- on demand jobs (running the lowest of all retains).

As v1.3.0 uses RunJobCommand also for scheduled jobs, we now need to adapt it in order to support both kind of executions; on demand ("_Enqueue now_" button in web UI) and scheduled jobs (which will run all the pending retains for a custom date/time). That's what this PR does.

Example job, with a default policy: daily, weekly, monthly enabled
- Scheduled job: it will run all the pending retains (Monthly->Weekly->Daily)
- Running the job using the "_Enqueue now_" button: will run only the lowest retain (Daily in this example)

_**Note** that after this change we cannot call run_job command directly from the CLI to run on demand tasks, as the job must be in the queue in order to run it. A new command enqueue_job could be implemented if we miss this feature._

PING @igorbga 