### PR TITLE
Fix jobs remaining warning message

### DIFF
--- a/src/Binovo/ElkarBackupBundle/Command/TickCommand.php
+++ b/src/Binovo/ElkarBackupBundle/Command/TickCommand.php
@@ -118,7 +118,7 @@ WHERE q.state = 'QUEUED'
 EOF;
                         $queuedJobs = $this->manager->createQuery($dql)->getSingleScalarResult();
 
-                        if ($queuedJobs == $queueCount && $noCandidate == false) {
+                        if ($queuedJobs == $queueCount > 0 && $noCandidate == false) {
                             $this->warn('There are jobs remaining but their configuration does not allow to execute them');
                             $noCandidate = true;
                         } else {

--- a/src/Binovo/ElkarBackupBundle/Command/TickCommand.php
+++ b/src/Binovo/ElkarBackupBundle/Command/TickCommand.php
@@ -118,7 +118,7 @@ WHERE q.state = 'QUEUED'
 EOF;
                         $queuedJobs = $this->manager->createQuery($dql)->getSingleScalarResult();
 
-                        if ($queuedJobs == $queueCount > 0 && $noCandidate == false) {
+                        if ($queuedJobs > 0 && $queuedJobs == $queueCount && $noCandidate == false) {
                             $this->warn('There are jobs remaining but their configuration does not allow to execute them');
                             $noCandidate = true;
                         } else {

--- a/src/Binovo/ElkarBackupBundle/Command/TickCommand.php
+++ b/src/Binovo/ElkarBackupBundle/Command/TickCommand.php
@@ -118,7 +118,9 @@ WHERE q.state = 'QUEUED'
 EOF;
                         $queuedJobs = $this->manager->createQuery($dql)->getSingleScalarResult();
 
-                        if ($queuedJobs > 0 && $queuedJobs == $queueCount && $noCandidate == false) {
+                        if ($queueCount == 0) {
+                            $noCandidate = true;
+                        } else if ($queuedJobs == $queueCount && $noCandidate == false) {
                             $this->warn('There are jobs remaining but their configuration does not allow to execute them');
                             $noCandidate = true;
                         } else {


### PR DESCRIPTION
This PR fixes the issue #328 

TickCommand checks for non-executable remaining jobs. However, the condition to check that situation is not correct as currently any scheduled backup job is sending that warning message at the end of the process.
```php
if ($queuedJobs == $queueCount && $noCandidate == false) {
    $this->warn('There are jobs remaining but their configuration does not allow to execute them');
    $noCandidate = true;
} else {
    $noCandidate = false;
}
```

Keeping that in mind, I've updated the condition:
```php
if ($queuedJobs > 0 && $queuedJobs == $queueCount && $noCandidate == false) {
    $this->warn('There are jobs remaining but their configuration does not allow to execute them');
    $noCandidate = true;
} else {
    $noCandidate = false;
}
```

However, I don't know how to provoke this situation to test it well.