### PR TITLE
Renew the DB connection after executing Rsnapshot

### DIFF
--- a/src/Binovo/ElkarBackupBundle/Command/RunJobCommand.php
+++ b/src/Binovo/ElkarBackupBundle/Command/RunJobCommand.php
@@ -237,6 +237,13 @@ class RunJobCommand extends LoggingCommand
             $data['ELKARBACKUP_JOB_STARTTIME']     = $job_starttime;
             $data['ELKARBACKUP_JOB_ENDTIME']       = $job_endtime;
             
+            // Renew the DB connection
+            $em = $this->getContainer()->get('doctrine')->getManager();
+            if ($em->getConnection()->ping() === false) {
+                $em->getConnection()->close();
+                $em->getConnection()->connect();
+            }
+            
             $queue = $container
             ->get('doctrine')
             ->getRepository('BinovoElkarBackupBundle:Queue')


### PR DESCRIPTION
This PR renews the DB connection after Rsnapshot command execution (if it's necessary).

More info: in some cases, MySQL connection dies after Rsnapshot execution (in RunJobCommand), causing the error described in #331

In v1.0.3 TickCommand was improved, renewing DB connection between commands to avoid these errors. However, we forgot RunJobCommand.