### PR TITLE
[Deb package] dependency changed to default-mysql-client

### DIFF
--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.3.2
 Section: admin
 Priority: optional
 Architecture: all
-Depends: acl, debconf, php5, php5-cli, rsnapshot, default-mysql-client | mysql-client, php5-mysql, sudo, apache2
+Depends: acl, debconf, php | php5, php-cli | php5-cli, rsnapshot, default-mysql-client | mysql-client, php-mysql | php5-mysql, sudo, apache2
 Suggests: autofs5, bzip2, zip, mysql-server, tahoe-lafs
 Maintainer: Xabi Ezpeleta <xezpeleta@gmail.com>
 Description: backup solution with an easy-to-use web interface based on Rsync / RSnapshot

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.3.2
 Section: admin
 Priority: optional
 Architecture: all
-Depends: acl, debconf, php5, php5-cli, rsnapshot, mysql-client, php5-mysql, sudo, apache2
+Depends: acl, debconf, php5, php5-cli, rsnapshot, default-mysql-client | mysql-client, php5-mysql, sudo, apache2
 Suggests: autofs5, bzip2, zip, mysql-server, tahoe-lafs
 Maintainer: Xabi Ezpeleta <xezpeleta@gmail.com>
 Description: backup solution with an easy-to-use web interface based on Rsync / RSnapshot

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: elkarbackup
-Version: 1.3.2
+Version: 1.3.2-1
 Section: admin
 Priority: optional
 Architecture: all


### PR DESCRIPTION
Fixes #393 

Changed from "mysql-client" to "default-mysql-client" as dependency. We keep "mysql-client" as an alternative package name (pipe symbol)