### PR TITLE
Fix log-path to download log files #313

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Bugfixes:
 - Change delivery address of swiftmailer in config_dev to "example@example.com"(closes #411)
 - Fix postscript handling in Job entity (closes #400)
 - Fixed XSS in Job and Client lists (closes #427)
+- Fix path for the log files to download (closes #313)
 
 ## 1.3.4 (2020/12/06)
 Bugfixes:

--- a/src/Binovo/ElkarBackupBundle/Resources/views/Default/logs.html.twig
+++ b/src/Binovo/ElkarBackupBundle/Resources/views/Default/logs.html.twig
@@ -38,7 +38,7 @@
         <td>{{ logRecord.source }}</td>
         <td>{{ logRecord.userName }}</td>
         <td>{{ logRecord.message }}</td>
-        <td>{% if (logRecord.logfile) %} <a href="/log/{{ logRecord.id }}/download"><span class="glyphicon glyphicon-file" title="{% trans %}Logfile{% endtrans %}"></span></a>{% endif %}</td>
+        <td>{% if (logRecord.logfile) %} <a href="{{ url_prefix }}/log/{{ logRecord.id }}/download"><span class="glyphicon glyphicon-file" title="{% trans %}Logfile{% endtrans %}"></span></a>{% endif %}</td>
         <td style="white-space: nowrap;">{% if logRecord.link %}<a href="{{ logRecord.link }}">{{ logRecord.link }}</a>{% endif %}</td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
Fixed path to download log files from error logs, url-prefix added, issue-313 resolved.