### PR TITLE
Docker image required changes for Symfony 3.4 #446

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 ## Bootstrap & Build elkarbackup
 ##
 
-FROM php:7.1-cli-alpine
+FROM php:7.3-cli-alpine
 
 RUN apk add --no-cache \
       git \
@@ -86,7 +86,7 @@ RUN set -ex; \
 ##
 
 
-FROM php:7.1-apache
+FROM php:7.3-apache
 RUN apt-get update && apt-get install -y \
       default-mysql-client \
       acl \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -41,10 +41,10 @@ done
 cd "${EB_DIR}"
 
 # Create/update database
-php app/console doctrine:database:create
-php app/console doctrine:migrations:migrate --no-interaction
+php bin/console doctrine:database:create
+php bin/console doctrine:migrations:migrate --no-interaction
 # Create admin user
-php app/console elkarbackup:create_admin
+php bin/console elkarbackup:create_admin
 
 # Set permissions
 setfacl -R -m u:www-data:rwX app/cache app/sessions app/logs
@@ -55,8 +55,8 @@ if [ ! -z "$SYMFONY__EB__PUBLIC__KEY" ] && [ ! -f "$SYMFONY__EB__PUBLIC__KEY" ];
 fi
 
 # Clear cache and sessions, build assetics...
-php app/console cache:clear
-php app/console assetic:dump
+php bin/console cache:clear
+php bin/console assetic:dump
 
 # Empty sessions
 rm -rf app/sessions/*
@@ -65,7 +65,7 @@ rm -rf app/cache/*
 apache2-foreground &
 
 ### Force tick execution and set permissions (again)
-php app/console elkarbackup:tick --env=prod > /var/log/output.log
+php bin/console elkarbackup:tick --env=prod > /var/log/output.log
 setfacl -R -m u:www-data:rwX app/cache app/sessions app/logs
 setfacl -dR -m u:www-data:rwX app/cache app/sessions app/logs
 
@@ -73,7 +73,7 @@ setfacl -dR -m u:www-data:rwX app/cache app/sessions app/logs
 if [ "${EB_CRON}" == "enabled" ]; then
   echo -e "\n\nEB_CRON is enabled. Running tick command every minute..."
   while true; do
-    php app/console elkarbackup:tick --env=prod &>/var/log/output.log &
+    php bin/console elkarbackup:tick --env=prod &>/var/log/output.log &
     sleep 60
   done
 fi


### PR DESCRIPTION
Due to the upgrade to Symfony 3.4, we need to adapt the Docker image. This PR do the following changes (#446 ):

-  Upgrade from PHP 7.1 to 7.3 (or higher) in Docker image
-  Change console path from app/console to bin/console

Even with this patch Elkarbackup docker image is not working, as we have some issues related with the configuration files (I will open the corresponding issue).