### PR TITLE
Github action: build the deb package automatically

### DIFF
--- a/.github/workflows/publish-deb-package.yml
+++ b/.github/workflows/publish-deb-package.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    tags:
+      - '*'
+
+name: Build and publish Debian package
+
+jobs:
+  build:
+    name: Build and publish Debian package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Build Debian package
+        run: |
+                docker run --rm -v ${{ github.workspace }}:/data/elkarbackup -v ${{ github.workspace }}:/export elkarbackup/debpkg
+      - name: Upload Debian package
+        uses: alexellis/upload-assets@0.2.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '["./build/*"]'


### PR DESCRIPTION
This Github Action will build and upload the Debian package automatically when we create a new Release.