### PR TITLE
Correct bug, undefined parameter in migrations

### DIFF
--- a/migrations/Version20180207095757.php
+++ b/migrations/Version20180207095757.php
@@ -31,8 +31,8 @@ class Version20180207095757 extends AbstractMigration implements LegacyBackupDir
         $this->addSql('CREATE INDEX IDX_C395A618615D27E1 ON Job (backupLocation_id)');
         
         //get backup_dir param and store as new BackupLocation
-        if ($this->backupDir != null) {
-            $location = $this->container->getParameter('backup_dir');
+        if ($this->backup_dir != null) {
+            $location = $this->backup_dir;
             $this->addSql("INSERT INTO BackupLocation VALUES(1,'Default','','" . $location . "',0)");
             
             $rootDir = $this->container->get('kernel')->getRootDir();

--- a/src/Migrations/LegacyBackupDirAwareInterface.php
+++ b/src/Migrations/LegacyBackupDirAwareInterface.php
@@ -4,6 +4,6 @@ namespace App\Migrations;
 interface LegacyBackupDirAwareInterface
 {
     //backup_dir parameter is not used since 2018 versions, but it is necessary to migrate from older versions
-    public function setLegacyBackupDir($backupDir): void;
+    public function setLegacyBackupDir(string $backupDir): void;
 }
 

--- a/src/Migrations/LegacyBackupDirAwareInterface.php
+++ b/src/Migrations/LegacyBackupDirAwareInterface.php
@@ -4,6 +4,6 @@ namespace App\Migrations;
 interface LegacyBackupDirAwareInterface
 {
     //backup_dir parameter is not used since 2018 versions, but it is necessary to migrate from older versions
-    public function setLegacyBackupDir(string $backupDir): void;
+    public function setLegacyBackupDir($backupDir): void;
 }
 


### PR DESCRIPTION
Corrected 'backup_dir' parameter's name bug. 'backup_dir' was defined in trait and 'backupDir' was called.