### PR TITLE
Correct parameter name APP_ENV. Fixes issue #470

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,8 +4,8 @@ source /envars.sh
 
 EB_DIR=/app/elkarbackup
 
-if [ -z "$SYMFONY_ENV" ];then
-  export SYMFONY_ENV=prod
+if [ -z "$APP_ENV" ];then
+  export APP_ENV=prod
 fi
 
 ## = Set timezone =

--- a/docker/envars.sh
+++ b/docker/envars.sh
@@ -1,6 +1,6 @@
 # Default environment variables
 
-export SYMFONY_ENV=${SYMFONY_ENV:=prod}
+export APP_ENV=${APP_ENV:=prod}
 
 # ${SYMFONY database default configuration
 export SYMFONY__DATABASE__DRIVER=${SYMFONY__DATABASE__DRIVER:=pdo_mysql}


### PR DESCRIPTION
APP_ENV was named SYMFONY_ENV in previous versions and it was not updated. Now docker image is in prod environment by default.