### PR TITLE
Change index rename statement when upgrading DB for MariaDB (Issue #479)

### DIFF
--- a/migrations/Version20210315133526.php
+++ b/migrations/Version20210315133526.php
@@ -23,7 +23,10 @@ final class Version20210315133526 extends AbstractMigration
         $this->addSql('ALTER TABLE BackupLocation DROP tahoe, CHANGE maxParallelJobs maxParallelJobs INT NOT NULL');
         $this->addSql('ALTER TABLE Client CHANGE maxParallelJobs maxParallelJobs INT NOT NULL');
         $this->addSql('ALTER TABLE Job CHANGE backupLocation_id backupLocation_id INT DEFAULT NULL');
-        $this->addSql('ALTER TABLE Job RENAME INDEX idx_c395a618615d27e1 TO IDX_C395A61817EE0EA');
+        $this->addSql('ALTER TABLE Job DROP FOREIGN KEY FK_C395A618615D27E1');
+        $this->addSql('ALTER TABLE Job DROP INDEX idx_c395a618615d27e1');
+        $this->addSql('CREATE INDEX IDX_C395A61817EE0EA ON Job(backupLocation_id)');
+        $this->addSql('ALTER TABLE Job ADD CONSTRAINT FK_C395A618615D27E1 FOREIGN KEY IDX_C395A61817EE0EA(backupLocation_id) REFERENCES BackupLocation(id)');
     }
 
     public function down(Schema $schema) : void
@@ -32,6 +35,9 @@ final class Version20210315133526 extends AbstractMigration
         $this->addSql('ALTER TABLE BackupLocation ADD tahoe TINYINT(1) NOT NULL, CHANGE maxParallelJobs maxParallelJobs INT DEFAULT 1 NOT NULL');
         $this->addSql('ALTER TABLE Client CHANGE maxParallelJobs maxParallelJobs INT DEFAULT 1 NOT NULL');
         $this->addSql('ALTER TABLE Job CHANGE backupLocation_id backupLocation_id INT NOT NULL');
-        $this->addSql('ALTER TABLE Job RENAME INDEX idx_c395a61817ee0ea TO IDX_C395A618615D27E1');
+        $this->addSql('ALTER TABLE Job DROP FOREIGN KEY FK_C395A618615D27E1');
+        $this->addSql('ALTER TABLE Job DROP INDEX idx_c395a61817ee0ea');
+        $this->addSql('CREATE INDEX IDX_C395A618615D27E1 ON Job(backupLocation_id');
+        $this->addSql('ALTER TABLE Job ADD CONSTRAINT FK_C395A618615D27E1 FOREIGN KEY IDX_C395A618615D27E1(backupLocation_id) REFERENCES BackupLocation(id)');
     }
 }


### PR DESCRIPTION
Changed statements to rename index since MariaDB 10.3 does not support RENAME INDEX statement. First dropped the foreign key and the index and create it with the new name instead. Fixes issue #479