### PR TITLE
Proposal for blocking users with USER role - Issue 157

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.0~rc1 (2021/04/21)
 Security fixes:
   * Generate new Symfony secret on install or on upgrade if it was left unchanged (closes #481)
+  * Deprecate USER role users, blocking login, due to security issues (closes #157)
 
 Enhacements:
   * Remove Tahoe integration (closes #458)

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -53,4 +53,4 @@ security:
         - { path: ^/config/params                , roles: ROLE_ADMIN}
         - { path: ^/config/repositorybackupscript, roles: ROLE_ADMIN}
         - { path: ^/config/publickey/generate    , roles: ROLE_ADMIN}
-        - { path: ^/                             , roles: ROLE_USER}
+        - { path: ^/                             , roles: ROLE_ADMIN}

--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,7 @@ elkarbackup (2.0.0~rc1) stable; urgency=medium
   * [Security] Generate new Symfony secret on install or on upgrade if it was left unchanged (closes #481)
   * Pre/post script execution order changed to be alphabetic, pre ascending and post descending (closes #466)
   * Debian 11 Bullseye support (requires Debian 10 rsnaphost package installation, closes #456)
+  * [Security] Deprecate USER role users, blocking login, due to security issues (closes #157)
 
  --  Eneko Lacunza <elacunza@binovo.es>  Thu, 21 Apr 2021 16:00:00 +0100
 

--- a/translations/BinovoElkarBackup.en.yml
+++ b/translations/BinovoElkarBackup.en.yml
@@ -370,7 +370,7 @@ user_help: |
  <h4>Role</h4>
  <ul>
   <li><b>Admin</b>: admin users will be able to change anything</li>
-  <li><b>User</b>: limited users can only manage their own clients and jobs. Caution: they are able to see other users activity logs</li>
+  <li><b>User</b>: <span style="font-weight: bold; color: red">DEPRECATED</span> due to security <a href="https://github.com/elkarbackup/elkarbackup/issues/157">issue#157</a>. Can't login. Please change role to Admin or remove user.</li>
  </ul>
  <h4>Password</h4>
  You can't read the password in this field, you can only use it to change it. If you put anything but the empty string in this field and save the password will be updated.


### PR DESCRIPTION
This PR blocks login for users with USER role and updates user form side help.

Change is simple enough and allows us to make this breaking change for 2.0.0 easily.

If there are Elkarbackup admin out there that want to continue using USER roles, they can just adjust security.yaml to allow their login.

Closes #157