### PR TITLE
Add support for alternative MySQL providers, such as Percona

### DIFF
--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -3,8 +3,8 @@ Version: 2.0.0
 Section: admin
 Priority: optional
 Architecture: all
-Depends: acl, debconf, php, php-cli, php-xml, rsnapshot, default-mysql-client, php-mysql, sudo, apache2
-Suggests: autofs5, bzip2, zip, default-mysql-server
+Depends: acl, debconf, php, php-cli, php-xml, rsnapshot, default-mysql-client | virtual-mysql-client, php-mysql, sudo, apache2
+Suggests: autofs5, bzip2, zip, default-mysql-server | virtual-mysql-server
 Maintainer: Xabi Ezpeleta <xezpeleta@gmail.com>
 Description: backup solution with an easy-to-use web interface based on Rsync / RSnapshot
  ElkarBackup is a free open-source backup solution based on RSync/RSnapshot. It helps to manage centralized backups using a web interface.


### PR DESCRIPTION
At the moment, the `DEBIAN/control` file has just `default-mysql-client` and `default-mysql-server`, which limits us to only using the default MySQL client.

We prefer to use Percona builds of MySQL, so this innocuous change allows resulting elkarbackup deb files to use anything that provides `virtual-mysql-client` or `virtual-mysql-server` instead.