### PR TITLE
Generate the Symfony secret in Docker entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,6 +24,14 @@ if [ ! -z "$PHP_TZ" ];then
   printf "[PHP]\ndate.timezone = ${PHP_TZ}\n" > /usr/local/etc/php/conf.d/tzone.ini
 fi
 
+## = Generate Symfony secret =
+## Only if SYMFONY__SECRET has the default value
+
+if [ ! -z "$SYMFONY__EB__SECRET" ] && [ "$SYMFONY__EB__SECRET" == "ThisTokenIsNotSoSecretChangeItElkarbackup" ];then
+  SYMFONY__EB__SECRET=`tr -dc A-Za-z0-9 </dev/urandom | head -c 40`
+
+fi
+
 # Run commands
 if [ ! -z "$1" ]; then
   command="$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -29,7 +29,6 @@ fi
 
 if [ ! -z "$SYMFONY__EB__SECRET" ] && [ "$SYMFONY__EB__SECRET" == "ThisTokenIsNotSoSecretChangeItElkarbackup" ];then
   SYMFONY__EB__SECRET=`tr -dc A-Za-z0-9 </dev/urandom | head -c 40`
-
 fi
 
 # Run commands

--- a/docker/envars.sh
+++ b/docker/envars.sh
@@ -19,7 +19,7 @@ export SYMFONY__MAILER__PASSWORD=${SYMFONY__MAILER__PASSWORD:=null}
 export SYMFONY__MAILER__FROM=${SYMFONY__MAILER__FROM}
 
 # Elkarbackup default configuration
-export SYMFONY__EB__SECRET=${SYMFONY__EB__SECRET:=fba546d6ab6abc4a01391d161772a14e093c7aa2}
+export SYMFONY__EB__SECRET=${SYMFONY__EB__SECRET:=ThisTokenIsNotSoSecretChangeItElkarbackup}
 export SYMFONY__EB__UPLOAD__DIR=${SYMFONY__EB__UPLOAD__DIR:=/app/uploads}
 export SYMFONY__EB__BACKUP__DIR=${SYMFONY__EB__BACKUP__DIR:=/app/backups}
 export SYMFONY__EB__TMP__DIR=${SYMFONY__EB__TMP__DIR:=/app/tmp}


### PR DESCRIPTION
If the user doesn't change the value of `SYMFONY__EB__SECRET` environment variable, entrypoint.sh will generate a new one.

We also should encourage users to change its value in the documentation.

Issue #503 