### PR TITLE
Fix cache clear after changing parameters.

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -30,7 +30,7 @@ services:
     App\Controller\:
         resource: '../src/Controller/'
         tags: ['controller.service_arguments']
-        arguments: ["%kernel.cache_dir%", "%upload_dir%"]
+        arguments: ["%upload_dir%"]
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
     App\Listener\ScriptListener:

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -202,6 +202,11 @@ class DefaultController extends AbstractController
             } else {
                 $this->err('Command failure: ' . $commandAndParams['command']);
             }
+            // UGLY and NOT TOTALLY CORRECT
+            // We have to sleep after clearing the cache, beause otherwise
+            // subsequent calls (i.e. a redirect) won't load the correct data.
+            // See https://github.com/elkarbackup/elkarbackup/pull/553
+            // 2s seems an "always works" value in my dev environment
             sleep(2);
         } catch (Exception $e) {
             $this->err('Exception %exceptionmsg% running command %command%: ',

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -78,7 +78,7 @@ class DefaultController extends AbstractController
     private $encoderFactory;
     private $uploadDir;
 
-    public function __construct($cacheDir, $uploadDir, Security $security, TranslatorInterface $t, Logger $logger, PaginatorInterface $pag, KernelInterface $kernel, EncoderFactoryInterface $encoder)
+    public function __construct($uploadDir, Security $security, TranslatorInterface $t, Logger $logger, PaginatorInterface $pag, KernelInterface $kernel, EncoderFactoryInterface $encoder)
     {
         $this->kernel = $kernel;
         $this->security = $security;

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -33,7 +33,10 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Bridge\Monolog\Logger;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -47,6 +50,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
@@ -65,24 +69,22 @@ use Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer;
 
 class DefaultController extends AbstractController
 {
+    private $kernel;
     private $security;
     private $translator;
     private $logger;
     private $supportedLocales;
     private $paginator;
-    private $cacheDir;
-    private $cacheClearer;
     private $encoderFactory;
     private $uploadDir;
 
-    public function __construct($cacheDir, $uploadDir, Security $security, TranslatorInterface $t, Logger $logger, PaginatorInterface $pag, ChainCacheClearer $cci, EncoderFactoryInterface $encoder)
+    public function __construct($cacheDir, $uploadDir, Security $security, TranslatorInterface $t, Logger $logger, PaginatorInterface $pag, KernelInterface $kernel, EncoderFactoryInterface $encoder)
     {
-        $this->cacheDir = $cacheDir;
+        $this->kernel = $kernel;
         $this->security = $security;
         $this->translator = $t;
         $this->logger = $logger;
         $this->paginator = $pag;
-        $this->cacheClearer = $cci;
         $this->encoderFactory = $encoder;
         $this->uploadDir = $uploadDir;
     }
@@ -186,8 +188,27 @@ class DefaultController extends AbstractController
      */
     protected function clearCache()
     {
-        $realCacheDir = $this->cacheDir;
-        $this->cacheClearer->clear($realCacheDir);
+        try {
+            $commandAndParams = [
+                'command' => 'cache:clear',
+                '--env' => 'prod'
+            ];
+            $application = new Application($this->kernel);
+            $application->setAutoExit(false);
+            $input = new ArrayInput($commandAndParams);
+            $output = new BufferedOutput();
+            $status = $application->run($input, $output);
+            if (0 == $status) {
+                $this->info('Command success: ' . $commandAndParams['command']);
+            } else {
+                $this->err('Command failure: ' . $commandAndParams['command']);
+            }
+            sleep(2);
+        } catch (Exception $e) {
+            $this->err('Exception %exceptionmsg% running command %command%: ',
+                array('%exceptionmsg%' => $e->getMessage(), '%command%' => $commandAndParams['command'])
+            );
+        }
     }
 
     /**
@@ -2266,6 +2287,7 @@ EOF;
                     $t->trans('Parameters updated', array(), 'BinovoElkarBackup')
                 );
             }
+            $this->clearCache();
             $result = $this->redirect($this->generateUrl('manageParameters'));
         } else {
             $result = $this->render(
@@ -2279,8 +2301,6 @@ EOF;
             );
         }
         $this->getDoctrine()->getManager()->flush();
-        $this->clearCache();
-        
         return $result;
     }
 

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -190,8 +190,7 @@ class DefaultController extends AbstractController
     {
         try {
             $commandAndParams = [
-                'command' => 'cache:clear',
-                '--env' => 'prod'
+                'command' => 'cache:clear'
             ];
             $application = new Application($this->kernel);
             $application->setAutoExit(false);


### PR DESCRIPTION
This should close #538 .

I'm not particularly fond of the sleep but I can't see how to wait properly. Without the sleep, sometimes the redirected form doesn't show updated values yet.

Also, constructor's first parameter $cacheDir is no longer needed, but I don't know where to unwire it :)