### PR TITLE
Get complete array to assert job is in the list

### DIFF
--- a/tests/api/JobTest.php
+++ b/tests/api/JobTest.php
@@ -210,7 +210,7 @@ class JobTest extends BaseApiTestCase
             '@id' => '/api/jobs',
         ]);
         $collection = json_decode($response->getContent(), true)['hydra:member'];
-        self::assertTrue(in_array($job->getData(), $collection), "Assert job exists in collection");
+        self::assertTrue(in_array($job->getCompleteArray(), $collection), "Assert job exists in collection");
     }
 
     public function testGetJobsUnauthenticated(): void


### PR DESCRIPTION
If it is just checked the entity parameters the assertion will fail. Iri, id and type are also needed in the array.