### PR TITLE
Improve error message when client name exists (#554)

### DIFF
--- a/src/Service/ClientService.php
+++ b/src/Service/ClientService.php
@@ -91,6 +91,11 @@ class ClientService
                 ));
             }
         }
+        $clientName = $client->getName();
+        $repository = $this->em->getRepository('App:Client');
+        if (null != $repository->findOneBy(['name' => $clientName])) {
+            throw new Exception("Client name already exists");
+        }
         if ($client->getOwner() == null) {
             $client->setOwner($this->security->getToken()
                 ->getUser());

--- a/src/Service/ClientService.php
+++ b/src/Service/ClientService.php
@@ -94,7 +94,7 @@ class ClientService
         $clientName = $client->getName();
         $repository = $this->em->getRepository('App:Client');
         if (null != $repository->findOneBy(['name' => $clientName])) {
-            throw new Exception("Client name already exists");
+            throw new Exception("Client name ".$clientName." already exists");
         }
         if ($client->getOwner() == null) {
             $client->setOwner($this->security->getToken()

--- a/tests/api/ClientTest.php
+++ b/tests/api/ClientTest.php
@@ -67,8 +67,7 @@ class ClientTest extends BaseApiTestCase
         $this->postClient($httpClient, $client);
         $this->postClient($httpClient, $client);
         $this->assertResponseStatusCodeSame(400);
-        #Unsuitable error management issued in #554. Error message will change when issue is resolved
-        $this->assertHydraError("An exception occurred while executing 'INSERT INTO Client (description, isActive, name, url, quota, sshArgs, rsyncShortArgs, rsyncLongArgs, state, maxParallelJobs, data, owner_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params [null, 1, \"".$client->getName()."\", \"\", -1, null, null, null, \"NOT READY\", 1, null, 1]:\n\nSQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '".$client->getName()."' for key 'Client.UNIQ_C0E801635E237E06'");
+        $this->assertHydraError("Client name ".$client->getName()." already exists");
     }
 
     public function testCreateClientNonExistentOwner(): void


### PR DESCRIPTION
Check if client name exists before persisting in DB and throw clear error message. Enhacement issued in #554 and fixes issue #564 