### PR TITLE
Update name

### DIFF
--- a/src/Service/ClientService.php
+++ b/src/Service/ClientService.php
@@ -91,17 +91,19 @@ class ClientService
                 ));
             }
         }
-        if (!$client->getId()){
-            $clientName = $client->getName();
-            $repository = $this->em->getRepository('App:Client');
-            if (null != $repository->findOneBy(['name' => $clientName])) {
+        $clientName = $client->getName();
+        $repository = $this->em->getRepository('App:Client');
+        $existingClient = $repository->findOneBy(['name' => $clientName]);
+        if (null != $existingClient) {
+            if ($existingClient->getId() !== $client->getId()){
                 throw new Exception("Client name ".$clientName." already exists");
             }
-            if ($client->getOwner() == null) {
-                $client->setOwner($this->security->getToken()
-                    ->getUser());
-            }
         }
+        if ($client->getOwner() == null) {
+            $client->setOwner($this->security->getToken()
+                ->getUser());
+        }
+
         if ($client->getMaxParallelJobs() < 1) {
             throw new Exception('Max parallel jobs parameter should be positive integer');
         }

--- a/src/Service/ClientService.php
+++ b/src/Service/ClientService.php
@@ -91,16 +91,17 @@ class ClientService
                 ));
             }
         }
-        $clientName = $client->getName();
-        $repository = $this->em->getRepository('App:Client');
-        if (null != $repository->findOneBy(['name' => $clientName])) {
-            throw new Exception("Client name ".$clientName." already exists");
+        if (!$client->getId()){
+            $clientName = $client->getName();
+            $repository = $this->em->getRepository('App:Client');
+            if (null != $repository->findOneBy(['name' => $clientName])) {
+                throw new Exception("Client name ".$clientName." already exists");
+            }
+            if ($client->getOwner() == null) {
+                $client->setOwner($this->security->getToken()
+                    ->getUser());
+            }
         }
-        if ($client->getOwner() == null) {
-            $client->setOwner($this->security->getToken()
-                ->getUser());
-        }
-
         if ($client->getMaxParallelJobs() < 1) {
             throw new Exception('Max parallel jobs parameter should be positive integer');
         }

--- a/tests/api/ClientTest.php
+++ b/tests/api/ClientTest.php
@@ -244,6 +244,20 @@ class ClientTest extends BaseApiTestCase
         ]);
     }
 
+    public function testUpdateClientKeepSameName(): void
+    {
+        $httpClient = $this->authenticate();
+        $client = ClientMother::base();
+        $client = $this->postClient($httpClient, $client);
+        $updateClient = ClientMother::named($client->getName());
+        $updateClientJson = $updateClient->getData();
+        $httpClient->request('PUT', $client->getIri(), ['json' => $updateClientJson]);
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertJsonContains($updateClientJson);
+        $this->assertJsonContains($updateClient->getContext());
+    }
+
     public function testUpdateClientRepeatedName(): void
     {
         $httpClient = $this->authenticate();

--- a/tests/api/ClientTest.php
+++ b/tests/api/ClientTest.php
@@ -251,6 +251,7 @@ class ClientTest extends BaseApiTestCase
         $client = $this->postClient($httpClient, $client);
         $updateClient = ClientMother::named($client->getName());
         $updateClientJson = $updateClient->getData();
+        $updateClientJson['description'] = "Updated client's description";
         $httpClient->request('PUT', $client->getIri(), ['json' => $updateClientJson]);
         $this->assertResponseIsSuccessful();
         $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');


### PR DESCRIPTION
In PR #567 repeated name was checked each time client was saved (also when update), so it was not possible to update a client and leave it with the same name. Now it is checked if the name coincidence is with the same client (same id) or another one (ant throw exception)