### PR TITLE
Docker: Cron enabled by default

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -43,7 +43,6 @@ services:
     image: elkarbackup/elkarbackup:latest
     environment:
       SYMFONY__DATABASE__PASSWORD: "your-password-here"
-      EB_CRON: "enabled"
       volumes:
       - backups:/app/backups
       - uploads:/app/uploads
@@ -78,7 +77,7 @@ The following environment variables are also honored for configuring your ElkarB
 |----------|---------------|---------------|
 | TZ       | Europe/Paris  | Timezone      |
 | PHP_TZ   | Europe/Paris  | Timezone (PHP)|
-| EB_CRON  | disabled      | run tick command periodically|
+| EB_CRON  | enabled       | run tick command periodically|
 
 ### Database configuration
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       dockerfile: ./docker/Dockerfile
     environment:
       SYMFONY__DATABASE__PASSWORD: "your-password-here"
-      EB_CRON: "enabled"
     #volumes:
     #- backups:/app/backups
     #- uploads:/app/uploads

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -83,4 +83,7 @@ if [ -z "${EB_CRON}" ] || [ "${EB_CRON}" = "enabled" ]; then
     php bin/console elkarbackup:tick --env=prod &>/var/log/output.log &
     sleep 60
   done
+else
+  # Keep apache alive
+  tail -f /dev/null
 fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -76,8 +76,8 @@ php bin/console elkarbackup:tick --env=prod > /var/log/output.log
 setfacl -R -m u:www-data:rwX var/cache var/sessions var/log
 setfacl -dR -m u:www-data:rwX var/cache var/sessions var/log
 
-# Cron
-if [ "${EB_CRON}" == "enabled" ]; then
+# Cron (enabled by default)
+if [ -z "${EB_CRON}" ] || [ "${EB_CRON}" = "enabled" ]; then
   echo -e "\n\nEB_CRON is enabled. Running tick command every minute..."
   while true; do
     php bin/console elkarbackup:tick --env=prod &>/var/log/output.log &


### PR DESCRIPTION
This PR will set EB_CRON enabled by default.

If you don't want to have Tick command every minute with Cron, explicitly set the value to "disabled".

Fixes issue #576