### PR TITLE
Correcting wrong indentation for the volumes-level. This is wrong in …

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -43,7 +43,7 @@ services:
     image: elkarbackup/elkarbackup:latest
     environment:
       SYMFONY__DATABASE__PASSWORD: "your-password-here"
-      volumes:
+    volumes:
       - backups:/app/backups
       - uploads:/app/uploads
       - sshkeys:/app/.ssh


### PR DESCRIPTION
The docker-compose example has a wrong indentation in the docs and at dockerhub. This results in the following error:

```
# docker-compose up
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.elkarbackup.environment.volumes contains ["backups:/app/backups", "uploads:/app/uploads", "sshkeys:/app/.ssh"], which is an invalid type, it should be a string, number, or a null`
```