### PR TITLE
Fix rsnapshot config template for rsync_short_args

### DIFF
--- a/templates/default/rsnapshotconfig.txt.twig
+++ b/templates/default/rsnapshotconfig.txt.twig
@@ -137,7 +137,7 @@ lockfile	{{tmp}}/rsnapshot.{{idClient}}_{{idJob}}.pid
 #
 #rsync_short_args -a
 {% if rsyncShortArgs %}
-rsync_short_args	-a	{{rsyncShortArgs}}
+rsync_short_args	-a{{rsyncShortArgs}}
 {% endif %}
 #rsync_long_args	--delete --numeric-ids --relative --delete-excluded
 {% if useLocalPermissions %}


### PR DESCRIPTION
This will fix #573 , Simply delete the tab. I needed hardlink short arg 'H' for email server which use heavy use of hardlinks for cc/bcc. To my surprise rsync did not use the settings in the web ui, and the generated rsnapshot config had an extra tab. So i delete them on the template.