### PR TITLE
Add simple end2end test

### DIFF
--- a/.github/workflows/run-end2end-tests.yml
+++ b/.github/workflows/run-end2end-tests.yml
@@ -1,0 +1,64 @@
+---
+name: Elkarbackup end2end Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache pup binary
+        id: cache-pup
+        uses: actions/cache@v4
+        with:
+          path: pup
+          key: pup-v0.4.0-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Download pup (HTML parser)
+        if: steps.cache-pup.outputs.cache-hit != 'true'
+        run: |
+          curl -L \
+            https://github.com/ericchiang/pup/releases/download/v0.4.0/pup_v0.4.0_linux_$(dpkg --print-architecture).zip \
+              -o pup.zip
+          unzip pup.zip
+          rm pup.zip
+
+      - name: Install pup
+        run: sudo cp pup /usr/local/bin/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and cache application image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          tags: elkarbackup:test
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Cache mariadb:lts base image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/test
+          file: docker/test/Dockerfile.cache-mariadb
+          tags: local/mariadb-cache:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run test suite
+        run: docker/test_e2e/run_end2end_tests.sh

--- a/docker/test_e2e/docker-compose.yml
+++ b/docker/test_e2e/docker-compose.yml
@@ -1,0 +1,29 @@
+---
+services:
+  elkarbackup:
+    #build:
+    #  context: ../..
+    #  dockerfile: ./docker/Dockerfile
+    image: elkarbackup:test
+    environment:
+      SYMFONY_ENV: e2e
+      DATABASE_HOST: "db"
+      DATABASE_PORT: "3306"
+      DATABASE_NAME: "elkarbackuptests"
+      DATABASE_USER: "root"
+      DATABASE_PASSWORD: "root"
+      SYMFONY__DATABASE__PASSWORD: "root"
+      EB_CRON: "enabled"
+    ports:
+      - "80:80"
+    depends_on:
+      - db
+    volumes:
+      - ./tmp/backups:/var/spool/elkarbackup/backups
+      - ./tmp/sshkeys:/app/.ssh
+  db:
+    image: mariadb:lts
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - "3306:3306"

--- a/docker/test_e2e/run_end2end_tests.sh
+++ b/docker/test_e2e/run_end2end_tests.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -euo pipefail
+
+credentials="root:root"
+host="http://localhost"
+
+DIR=$(readlink -f "$(dirname "$0")")
+
+# Do we have all requirements
+if ! command -v pup > /dev/null 2>&1; then
+	echo "pup is missing. Please install https://github.com/ericchiang/pup"
+	exit 1
+fi
+if ! command -v curl > /dev/null 2>&1; then
+	echo "curl is missing."
+	exit 1
+fi
+
+trap cleanup EXIT
+
+function log_ok() {
+	echo -e "\033[1;32m✅ $1\033[0m"
+}
+
+function log_fail() {
+	echo -e "\033[1;31m❌ $1\033[0m"
+}
+
+function login() {
+	username=$(echo "$credentials" | cut -d: -f1)
+	password=$(echo "$credentials" | cut -d: -f2)
+	curl -s -c "${DIR}/tmp/cookies.txt" -X POST -v ${host}/login_check \
+	-F "_username=${username}" \
+	-F "_password=${password}"
+}
+
+function check_running() {
+	curl -Ls -X GET ${host} | pup 'title text{}' 2> /dev/null | grep -q 'ElkarBackup'
+}
+
+function cleanup() {
+	set +e
+	echo "::group::🧼 Cleaning up..."
+	docker compose -f "${DIR}/docker-compose.yml" down --remove-orphans
+	sudo rm -rf "${DIR}/tmp"
+	echo "::endgroup::"
+}
+
+echo "::group::⏫ Starting ElkarBackup for E2E tests..."
+mkdir -p "${DIR}/tmp"
+docker compose -f "${DIR}/docker-compose.yml" up -d --build elkarbackup
+echo "::endgroup::"
+
+echo "::group::⌛ Waiting for ElkarBackup to be ready..."
+cnt=6
+for i in $(seq 1 $cnt); do
+	if check_running; then
+		break
+	fi
+	if [ "$i" -eq $cnt ]; then
+		echo "Cotainer logs:"
+		docker compose -f "${DIR}/docker-compose.yml" --progress quiet logs elkarbackup
+		echo "Web output:"
+		curl -Lsv -X GET ${host} || true
+		log_fail "ElkarBackup is not ready after $cnt attempts..."
+		echo "::endgroup::"
+		exit 1
+	fi
+	sleep 5
+done
+log_ok "ElkarBackup is ready."
+echo "::endgroup::"
+
+log_ok "Success: All checks passed!"
+exit 0


### PR DESCRIPTION
Add some rudimentary functional end2end for now.

   - Build elkarbackup docker container
   - Start elkarbackup
   - Start database
   - Connect to webinterface and check that the title tag is "Elkarbackup"
   - Abort otherwise.

Simple for now, but the plan is to extend it and allow for an actual backup run and restore.

Related to #665 