### PR TITLE
Improve docker some more

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,6 @@ RUN apk add --no-cache \
       grep \
       mysql-client \
       acl \
-      rsnapshot \
     && docker-php-ext-install \
       pdo_mysql \
       pcntl
@@ -63,7 +62,7 @@ RUN set -ex; \
 COPY $DOCKERDIR/parameters.yaml.docker /app/elkarbackup/config/parameters.yaml.dist
 
 ## Custom monolog.yaml (to log to stderr)
-COPY $DOCKERDIR/monolog.yaml.docker /app/elkarbackup/config/packages/dev/monolog.yaml
+COPY $DOCKERDIR/monolog.yaml.docker /app/elkarbackup/config/packages/monolog.yaml
 
 ## Disable "Manage parameters" menu item
 COPY $DOCKERDIR/src/Builder.php /app/elkarbackup/src/Menu/Builder.php
@@ -133,7 +132,7 @@ RUN echo "elkarbackup ALL = NOPASSWD: ELKARBACKUP_SCRIPTS" >> /etc/sudoers.d/elk
 RUN echo "    IdentityFile /app/.ssh/id_rsa" >> /etc/ssh/ssh_config
 
 # Console commands log output
-RUN ln -sf /proc/1/fd/1 /var/log/output.log
+RUN ln -sf /dev/stdout /var/log/output.log
 
 ## Set timezone
 RUN ln -snf /usr/share/zoneinfo/Europe/Paris /etc/localtime && echo "Europe/Paris" > /etc/timezone

--- a/docker/monolog.yaml.docker
+++ b/docker/monolog.yaml.docker
@@ -4,7 +4,7 @@ monolog:
             type: stream
             path: php://stderr
             level: debug
-            channels: ["!event"]
+            channels: ["!event", "!deprecation", "!php"]
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration
         #firephp:

--- a/docker/test_e2e/run_end2end_tests.sh
+++ b/docker/test_e2e/run_end2end_tests.sh
@@ -17,18 +17,30 @@ if ! command -v curl > /dev/null 2>&1; then
 	exit 1
 fi
 
-NO_CLEAN=0
-usage() { echo "Usage: $0 [-n]" 1>&2; exit 1; }
+function cleanup() {
+	set +e
+	echo "::group::🧼 Cleaning up..."
+	docker compose -f "${DIR}/docker-compose.yml" down --remove-orphans
+	sudo rm -rf "${DIR}/tmp"
+	echo "::endgroup::"
+}
 
-while getopts ":n" o; do
-    case "${o}" in
-        n)
-            NO_CLEAN=1
-            ;;
-        *)
-            usage
-            ;;
-    esac
+NO_CLEAN=0
+usage() { echo "Usage: $0 [-n] [-c]" 1>&2; exit 1; }
+
+while getopts ":nc" o; do
+	case "${o}" in
+		n)
+			NO_CLEAN=1
+			;;
+		c)
+			cleanup
+			exit 0
+			;;
+		*)
+			usage
+			;;
+	esac
 done
 shift $((OPTIND-1))
 
@@ -112,14 +124,6 @@ function get_job_status() {
 		pup "tr[class*=\"client-${client_id} job-${job_id}\"] td[class\$=\"status\"] span text{}" | \
 		xargs \
 		|| echo "unknown"
-}
-
-function cleanup() {
-	set +e
-	echo "::group::🧼 Cleaning up..."
-	docker compose -f "${DIR}/docker-compose.yml" down --remove-orphans
-	sudo rm -rf "${DIR}/tmp"
-	echo "::endgroup::"
 }
 
 mkdir -p "${DIR}/tmp"


### PR DESCRIPTION
- Remove `rsnapshot` from the `apt-get` call. It is currently not shipping for debian.
- Fix logging in docker. The existing monolog config will only log to /dev/stdout if running
  in the `dev` environment. We actually want symphony logging in all environments.
- Filter `deprecation` log channel though. While this is important information to have, it
  would only clobber the logs and hide important information. Investigate a better way of
  getting those logs for future development.
- Add the `-c` parameter to the end2end test script. `-c` stands for clean and will clean up.
  This is a useful extension for the `-n` no-cleanup parameter and allows for easier testing.
