### PR TITLE
Fix client/job/config route

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -746,7 +746,7 @@ class DefaultController extends AbstractController
         }
         $backupDir = $job->getBackupLocation()->getEffectiveDir();
         $client = $job->getClient();
-        $logDir = $this->container->get('kernel')->getLogDir();
+        $logDir = $this->kernel->getLogDir();
         $tmpDir = $this->tmp_dir;
         $sshArgs = $client->getSshArgs();
         $rsyncShortArgs = $client->getRsyncShortArgs();


### PR DESCRIPTION
https://github.com/elkarbackup/elkarbackup/issues/597 documents an
error in the `showJobConfig()` function.

This seems related to a symfony update which restricts access to
the full container.

`container->get('kernel')` does not work anymore and needs to be handled
by injecting the kernel into the current object.
Luckily this is already done, so all we have to do is use the existing
`$this->kernel` object.

Fixes #597.
