### PR TITLE
Improve Docker Parameter overides

### DIFF
--- a/config/parameters.yaml.dist
+++ b/config/parameters.yaml.dist
@@ -26,4 +26,4 @@ parameters:
     home: /var/lib/elkarbackup
     max_parallel_jobs: 1
     post_on_pre_fail: true
-    app.version: 'v2.3.2'
+    app.version: 'v2.3.3'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,8 @@ ENV DOCKERDIR=./docker
 
 ## Composer install
 COPY composer.json composer.lock .
-COPY $DOCKERDIR/parameters.yaml.docker /app/elkarbackup/config/parameters.yaml.dist
+COPY config/parameters.yaml.dist /app/elkarbackup/config/parameters.yaml.dist
+COPY $DOCKERDIR/parameters.yaml.docker /app/elkarbackup/config/parameters.yaml
 RUN set -ex && \
       cd /app/elkarbackup && \
       mkdir -p public/css public/fonts public/js public/js/bootstrap public/js/moment public/js/jquery && \

--- a/docker/parameters.yaml.docker
+++ b/docker/parameters.yaml.docker
@@ -11,19 +11,13 @@ parameters:
     mailer_user: '%env(SYMFONY__MAILER__USER)%'
     mailer_password: '%env(SYMFONY__MAILER__PASSWORD)%'
     mailer_from: '%env(SYMFONY__MAILER__FROM)%'
-    locale: en
     secret: '%env(SYMFONY__EB__SECRET)%'
     upload_dir: '%env(SYMFONY__EB__UPLOAD__DIR)%'
     backup_dir: '%env(SYMFONY__EB__BACKUP__DIR)%'
     public_key: '%env(SYMFONY__EB__PUBLIC__KEY)%'
-    max_log_age: P1Y
     tmp_dir: '%env(SYMFONY__EB__TMP__DIR)%'
     rsnapshot: /usr/local/bin/rsnapshot
-    warning_load_level: 0.8
-    pagination_lines_per_page: 20
     url_prefix: '%env(SYMFONY__EB__URL__PREFIX)%'
-    disable_background: false
     home: /app/elkarbackup
     max_parallel_jobs: '%env(SYMFONY__EB__MAX__PARALLEL__JOBS)%'
     post_on_pre_fail: '%env(SYMFONY__EB__POST__ON__PRE__FAIL)%'
-    app.version: 'v2.3.2'


### PR DESCRIPTION
The current docker build proces has a modified `parameters.yml.dist` file that
overwrites the regular file in the `config/` directory during docker build.

This means we need to manually keep a second file and sync changes.

Instead, we can inmprove on this process. Keep the regular `parameters.yml.dist`
file around and add the changes required for docker as `parameters.yml' during
build time.
At runtime, these two configs get merged and we only have to modify one file.
