### PR TITLE
Place optional parameters last so that autowiring can work properly

### DIFF
--- a/src/Logger/LoggerHandler.php
+++ b/src/Logger/LoggerHandler.php
@@ -26,7 +26,7 @@ class LoggerHandler extends AbstractProcessingHandler implements ContainerAwareI
     private $messages;
     private $isRecordingMessage;
 
-    public function __construct($level = Logger::DEBUG, $bubble = true, EntityManagerInterface $em)
+    public function __construct(EntityManagerInterface $em, $level = Logger::DEBUG, $bubble = true)
     {
         parent::__construct($level, $bubble);
         $this->em = $em;


### PR DESCRIPTION
Fixes elkarbackup/elkarbackup#635

Using the bin/console was triggering an autowiring error with a Logger class
when instantiating it.

Thank you to @adrianles for the fix.