### PR TITLE
Allow for Trusted Headers from a Proxy server.

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -2,8 +2,10 @@ name: Publish Docker images
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   main:
@@ -15,12 +17,23 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
 
-      - name: Docker meta
-        id: meta
+      - name: GHCR metadata (master)
+        if: github.ref == 'refs/heads/master'
+        id: meta_master
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value={{sha}}
+          flavor: |
+            latest=false
+
+      - name: GHCR metadata (tag)
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: meta_tag
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value={{sha}}
             type=semver,pattern={{version}}
@@ -43,18 +56,38 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
-        id: docker_build
+      - name: Build and push (master)
+        if: github.ref == 'refs/heads/master'
+        id: docker_build_master
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta_master.outputs.tags }}
+          labels: ${{ steps.meta_master.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Build and push (tag)
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: docker_build_tag
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: ${{ steps.meta_tag.outputs.tags }}
+          labels: ${{ steps.meta_tag.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image digest (master)
+        if: github.ref == 'refs/heads/master'
+        run: echo ${{ steps.docker_build_master.outputs.digest }}
+
+      - name: Image digest (tag)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: echo ${{ steps.docker_build_tag.outputs.digest }}

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -12,6 +12,15 @@ framework:
     templating:      { engines: ['twig'] } #assets_version: SomeVersionScheme
     default_locale:  '%locale%'
 
+    # Trusted proxies and headers for HTTPS scheme detection
+    trusted_proxies: '%trusted_proxies%'
+    trusted_headers:
+        - x-forwarded-for
+        - x-forwarded-proto
+        - x-forwarded-host
+        - x-forwarded-port
+        - x-forwarded-prefix
+
     session:
         handler_id: null
         cookie_secure: auto

--- a/config/parameters.yaml.dist
+++ b/config/parameters.yaml.dist
@@ -27,3 +27,4 @@ parameters:
     max_parallel_jobs: 1
     post_on_pre_fail: true
     app.version: 'v2.3.5'
+    trusted_proxies: null

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,57 +1,67 @@
 # ElkarBackup
 
 ## Images
-- 2.1.0, 2.1, 2, **latest (default)** 
+
+- 2.1.0, 2.1, 2, **latest (default)**
 - 2.0.2, 2.0
 - 1.3.5
 
 ## How to use this image
 
 ```sh
-$ docker run --name my-elkarbackup --link some-mysql:mysql -d elkarbackup/elkarbackup:latest
+$ docker run --name my-elkarbackup --link mariadb:lts -d ghcr.io/elkarbackup/elkarbackup:latest
 ```
 
-## Also hosted on GitHub Container Registry
-- DockerHub image is at `elkarbackup/elkarbackup:<version>`
+## Hosted on GitHub Container Registry
+
 - GitHub image is at `ghcr.io/elkarbackup/elkarbackup:<version>`
-- Since v2.0.x they both carry the same images
-- This can be useful if you're already hitting DockerHub's rate limits and can't pull the proxy from DockerHub
 
 ### Where to store data
+
 Docker container does not come with persistent storage. However, there are
 several ways to store data in the host machine. We encourage users to
 familiarize themselves with the [options available](https://docs.docker.com/storage/).
 
 Below you have the directories you might want to persist:
 
-| path           | description                        |
-|----------------|------------------------------------|
-| /app/backups   | Default backup storage directory.  |
-| /app/uploads   | Pre and post scripts.              |
-| /app/.ssh      | SSH keys.                          |
+| path         | description                       |
+| ------------ | --------------------------------- |
+| /app/backups | Default backup storage directory. |
+| /app/uploads | Pre and post scripts.             |
+| /app/.ssh    | SSH keys.                         |
+
+The automatically generated SSH key ElkarBackup uses to connect to remote machines can be found in the /app/.ssh/id_rsa.pub file which would be mounted on your host.
 
 ### ... via `docker-compose`
 
 You can use **Docker Compose** to easily run ElkarBackup in an isolated environment built with Docker containers:
 
 **docker-compose.yml**
-```yaml
-version: '3'
 
+```yaml
+---
 services:
   elkarbackup:
-    image: elkarbackup/elkarbackup:latest
+    image: ghcr.io/elkarbackup/elkarbackup:latest
     environment:
       SYMFONY__DATABASE__PASSWORD: "your-password-here"
+      EB_CRON: "enabled"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80"]
+      timeout: 2s
+      interval: 30s
+      start_period: 60s
     volumes:
       - backups:/app/backups
       - uploads:/app/uploads
       - sshkeys:/app/.ssh
     ports:
       - 8000:80
-    
+    requires:
+      - db
+
   db:
-    image: mysql:5.7.22
+    image: mariadb:lts
     environment:
       MYSQL_ROOT_PASSWORD: "your-password-here"
     volumes:
@@ -59,12 +69,33 @@ services:
 
 volumes:
   db:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ./mariadb
   backups:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ./backups
   uploads:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ./uploads
   sshkeys:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ./sshkeys
 ```
 
 Run `docker-compose up`, wait for it to initialize completely, and go the address:
+
 - http://localhost:8000
 
 ## Environment variables
@@ -73,47 +104,45 @@ The following environment variables are also honored for configuring your ElkarB
 
 ### General
 
-| name     | default value | description   |
-|----------|---------------|---------------|
-| TZ       | Europe/Paris  | Timezone      |
-| PHP_TZ   | Europe/Paris  | Timezone (PHP)|
-| EB_ACL   | enabled       | use setfacl, otherwise use chown|
-| EB_CRON  | enabled       | run tick command periodically|
+| name    | default value | description                      |
+| ------- | ------------- | -------------------------------- |
+| TZ      | Europe/Paris  | Timezone                         |
+| PHP_TZ  | Europe/Paris  | Timezone (PHP)                   |
+| EB_ACL  | enabled       | use setfacl, otherwise use chown |
+| EB_CRON | enabled       | run tick command periodically    |
 
 ### Database configuration
 
-| name                        | default value | description |
-|-----------------------------|---------------|-------------|
-| SYMFONY__DATABASE__DRIVER   | pdo_mysql     | driver      |
+| name                        | default value | description      |
+| --------------------------- | ------------- | ---------------- |
+| SYMFONY__DATABASE__DRIVER   | pdo_mysql     | driver           |
 | SYMFONY__DATABASE__PATH     | null          | db path (sqlite) |
-| SYMFONY__DATABASE__HOST     | db            | db host     |
-| SYMFONY__DATABASE__PORT     | 3306          | db port     |
-| SYMFONY__DATABASE__NAME     | elkarbackup   | db name     |
-| SYMFONY__DATABASE__USER     | root          | db user     |
-| SYMFONY__DATABASE__PASSWORD | root          | db password |
-
+| SYMFONY__DATABASE__HOST     | db            | db host          |
+| SYMFONY__DATABASE__PORT     | 3306          | db port          |
+| SYMFONY__DATABASE__NAME     | elkarbackup   | db name          |
+| SYMFONY__DATABASE__USER     | root          | db user          |
+| SYMFONY__DATABASE__PASSWORD | root          | db password      |
 
 ### Mailer configuration
 
-| name                        | default value | description  |
-|-----------------------------|---------------|--------------|
-| SYMFONY__MAILER__TRANSPORT  | smtp          | transport    |
-| SYMFONY__MAILER__HOST       | localhost     | host         |
-| SYMFONY__MAILER__USER       | null          | user         |
-| SYMFONY__MAILER__PASSWORD   | null          | password     |
-| SYMFONY__MAILER__FROM       | null          | from address |
-
+| name                       | default value | description  |
+| -------------------------- | ------------- | ------------ |
+| SYMFONY__MAILER__TRANSPORT | smtp          | transport    |
+| SYMFONY__MAILER__HOST      | localhost     | host         |
+| SYMFONY__MAILER__USER      | null          | user         |
+| SYMFONY__MAILER__PASSWORD  | null          | password     |
+| SYMFONY__MAILER__FROM      | null          | from address |
 
 ### Elkarbackup configuration
 
-| name                        | default value     | description |
-|-----------------------------|-------------------|-------------|
-| SYMFONY__EB__SECRET  | random value will be generated | framework secret |
-| SYMFONY__EB__UPLOAD__DIR         | /app/uploads | scripts directory |
-| SYMFONY__EB__BACKUP__DIR         | /app/backups | backups directory |
-| SYMFONY__EB__TMP__DIR            | /app/tmp     | tmp directory |
-| SYMFONY__EB__URL__PREFIX         | null         | url path prefix (i.e. /elkarbackup) |
-| SYMFONY__EB__PUBLIC__KEY         | /app/.ssh/id_rsa.pub | ssh public key path |
-| SYMFONY__EB__MAX__PARALLEL__JOBS | 1            | max parallel jobs |
-| SYMFONY__EB__POST__ON__PRE__FAIL | true         | post on pre fail |
-
+| name                               | default value                  | description                                          |
+| ---------------------------------- | ------------------------------ | ---------------------------------------------------- |
+| SYMFONY__EB__SECRET                | random value will be generated | framework secret                                     |
+| SYMFONY__EB__UPLOAD\_\_DIR         | /app/uploads                   | scripts directory                                    |
+| SYMFONY__EB__BACKUP\_\_DIR         | /app/backups                   | backups directory                                    |
+| SYMFONY__EB__TMP\_\_DIR            | /app/tmp                       | tmp directory                                        |
+| SYMFONY__EB__URL\_\_PREFIX         | null                           | url path prefix (i.e. /elkarbackup)                  |
+| SYMFONY__EB__PUBLIC\_\_KEY         | /app/.ssh/id_rsa.pub           | ssh public key path                                  |
+| SYMFONY__EB__MAX**PARALLEL**JOBS   | 1                              | max parallel jobs                                    |
+| SYMFONY__EB__POST**ON**PRE\_\_FAIL | true                           | post on pre fail                                     |
+| SYMFONY__EB__TRUSTED_PROXIES       | null                           | Comma separated list of proxies we trust for headers |

--- a/docker/parameters.yaml.docker
+++ b/docker/parameters.yaml.docker
@@ -21,3 +21,4 @@ parameters:
     home: /app/elkarbackup
     max_parallel_jobs: '%env(SYMFONY__EB__MAX__PARALLEL__JOBS)%'
     post_on_pre_fail: '%env(SYMFONY__EB__POST__ON__PRE__FAIL)%'
+    trusted_proxies: '%env(SYMFONY__EB__TRUSTED_PROXIES)%'


### PR DESCRIPTION
In case of a reverse proxy in front of elkarbackup, elkarbackup does
not know about protocols when building URLs because the backend connection
of the proxy might be different than the frontend connection.

While elkarbackup seems to exclusively use relative URLs, the symfony framework
will generate absolute URLs when doing redirects etc.

To prevent a https -> http redirect in such cases, allow to set trusted proxies
from which we accept header hints about protocol and remote addresses.

See https://symfony.com/doc/current/deployment/proxies.html for reference.

To configure these in the elkarbackup container, set the `SYMFONY__EB__TRUSTED_PROXIES`
variable.

Drive-By: Minor updates to the Docker README and compose file.
Drive-By: Build every commit to master as a docker image, but only tag with the SHA.
