### PR TITLE
Provide a potential fix for #617 (SQL INSERT error due to the field size being exceeded.)

### DIFF
--- a/src/Entity/LogRecord.php
+++ b/src/Entity/LogRecord.php
@@ -69,13 +69,33 @@ class LogRecord
       */
     protected $logFile;
 
+    /**
+     * Truncate message to given length
+     *
+     * @param mixed $msg
+     * @param integer $length
+     * @return mixed
+     */
+    private function truncateMsg($msg, $length = 255)
+    {
+        if ($msg === null) {
+            return null;
+        } else {
+            if (mb_strlen($msg) > $length) {
+                // Truncate to match column length (255 here)
+                return mb_substr($msg, 0, $length - 3) . "...";
+            }
+            return $msg;
+        }
+    }
+
     public function __construct($channel, $dateTime, $level, $levelName, $message, $link = NULL, $source = NULL, $userId = NULL, $userName = NULL, $logFile = NULL)
     {
         $this->channel   = $channel;
         $this->dateTime  = $dateTime;
         $this->level     = $level;
         $this->levelName = $levelName;
-        $this->link      = $link;
+        $this->link      = $this->truncateMsg($link, 255);
         $this->message   = $message;
         $this->source    = $source;
         $this->userId    = $userId;


### PR DESCRIPTION
This commit is a potential fix for such a situation as the link would be truncated to 255 chars as part of the ORM handler and would therefore fix #617.

I am uncertain if this is the best approach however. This does truncate the link entry when doing the INSERT.
The benefit is, that the app will not crash anymore.
The drawback however is, that the link on the display is now leading to a 404 error.
Still, 404 is better than 500...
And the screen is already looking bad in such a situation due to the really long strings messing with the layout.
<img width="1366" height="441" alt="image" src="https://github.com/user-attachments/assets/49cea186-d11e-413b-98ca-18457e65a5cb" />
One more 404 is certainly not much worse.

An alternative approache could be to change the ORM to declare the field as text, which gives longer link lengths.
Or we could stop these kind of debug messages having a link in the first place?
Maybe there's an even better idea?

@xezpeleta do you have an idea? Or maybe someone else from the previous developer team?